### PR TITLE
Alter cookie name for traffic source

### DIFF
--- a/lead-conversion.php
+++ b/lead-conversion.php
@@ -36,8 +36,8 @@ class LeadConversion {
       $form_data["c_utmz"] = $_COOKIE["__utmz"];
     }
 
-    if ( isset($_COOKIE["__trf_src"]) && empty($form_data["traffic_source"]) ) {
-      $form_data["traffic_source"] = $_COOKIE["__trf_src"];
+    if ( isset($_COOKIE["__trf.src"]) && empty($form_data["traffic_source"]) ) {
+      $form_data["traffic_source"] = $_COOKIE["__trf.src"];
     }
 
     if (empty($form_data["client_id"]) && !empty($_COOKIE["rdtrk"])) {

--- a/rdstation-wp.php
+++ b/rdstation-wp.php
@@ -4,7 +4,7 @@
 Plugin Name: 	Integração RD Station
 Plugin URI: 	https://wordpress.org/plugins/integracao-rdstation
 Description:  Integre seus formulários de contato do WordPress com o RD Station
-Version:      2.3
+Version:      2.3.1
 Author:       Resultados Digitais
 Author URI:   http://resultadosdigitais.com.br
 License:      GPL2


### PR DESCRIPTION
No código javascript de monitoramento está criando um cookie com nome "__trf.src" e o plugin busca pelo nome "__trf_src" por isso não consegue encontrar.