### PR TITLE
Update add_custom_scripts.php

### DIFF
--- a/metaboxes/add_custom_scripts.php
+++ b/metaboxes/add_custom_scripts.php
@@ -68,6 +68,9 @@ function rdscript_updates($pID) {
   // if the function is called by the WP autosave feature, nothing must be saved
   if ( defined('DOING_AUTOSAVE') && DOING_AUTOSAVE )
     return;
+	
+  if ( !isset( $_POST['wpwox_noncename'] ) )
+    return;
 
   // verify this came from the our screen and with proper authorization,
   // because save_post can be triggered at other times


### PR DESCRIPTION
Em alguns salvamentos de post não há o índice "wpwox_noncename". Com isso Notice é gerado e inviabiliza alguns redirects nativos e de outros plugins, uma vez que acontecerá o clássico "Cannot modify header information"