### PR TITLE
Prepare plugin for internationalization

### DIFF
--- a/metaboxes/RD_Metabox.php
+++ b/metaboxes/RD_Metabox.php
@@ -2,6 +2,8 @@
 
 class RD_Metabox {
 
+	protected $text_domain = 'rdstation-wp';
+
 	public function __construct($plugin_prefix){
 		$this->plugin_prefix = $plugin_prefix;
 		add_action( 'add_meta_boxes', array($this, 'rd_create_meta_boxes' ) );
@@ -11,7 +13,7 @@ class RD_Metabox {
 	public function rd_create_meta_boxes(){
 		add_meta_box(
       'form_identifier_box',
-      'Identificador',
+      __('Identificador', $text_domain),
       array($this, 'form_identifier_box_content'),
       $this->plugin_prefix.'_integrations',
       'normal'
@@ -19,7 +21,7 @@ class RD_Metabox {
 
     add_meta_box(
       'token_rdstation_box',
-      'Token RD Station',
+      __('Token RD Station', $text_domain),
       array($this, 'token_rdstation_box_content'),
       $this->plugin_prefix.'_integrations',
       'normal'
@@ -27,7 +29,7 @@ class RD_Metabox {
 
 	  add_meta_box(
       'form_id_box',
-      'Qual formulário você deseja integrar ao RD Station?',
+      __('Qual formulário você deseja integrar ao RD Station?', $text_domain),
       array($this, 'form_id_box_content'),
       $this->plugin_prefix.'_integrations',
       'normal'
@@ -38,14 +40,17 @@ class RD_Metabox {
 	    $identifier = get_post_meta(get_the_ID(), 'form_identifier', true);
 	    $use_post_title = get_post_meta(get_the_ID(), 'use_post_title', true); ?>
 	    <input type="text" name="form_identifier" value="<?php echo $identifier; ?>">
-	    <span class="rd-integration-tips">Esse identificador irá lhe ajudar a saber o formulário de origem do lead.</span>
+	    <span class="rd-integration-tips">
+				<?php _e('Esse identificador irá ajudar a saber o formulário de origem do lead.', $text_domain) ?>
+			</span>
 	    <?php
 	}
 
 	public function token_rdstation_box_content(){
 	    $token = get_post_meta(get_the_ID(), 'token_rdstation', true); ?>
 	    <input type="text" name="token_rdstation" size="32" value="<?php echo $token ?>">
-	    <span class="rd-integration-tips">Não sabe seu token? <a href="https://www.rdstation.com.br/integracoes" target="blank">Clique aqui</a></span>
+	    <span class="rd-integration-tips">
+				<?php _e('Não sabe seu token?', $text_domain) ?> <a href="https://app.rdstation.com.br/integracoes" target="blank"><?php _e('Clique aqui', $text_domain) ?></a></span>
 	    <?php
 	}
 

--- a/metaboxes/RD_Metabox.php
+++ b/metaboxes/RD_Metabox.php
@@ -2,7 +2,7 @@
 
 class RD_Metabox {
 
-	protected $text_domain = 'rdstation-wp';
+	static $text_domain = 'rdstation-wp';
 
 	public function __construct($plugin_prefix){
 		$this->plugin_prefix = $plugin_prefix;

--- a/metaboxes/RD_Metabox.php
+++ b/metaboxes/RD_Metabox.php
@@ -2,7 +2,7 @@
 
 class RD_Metabox {
 
-	static $text_domain = 'rdstation-wp';
+	public $text_domain = 'rdstation-wp';
 
 	public function __construct($plugin_prefix){
 		$this->plugin_prefix = $plugin_prefix;
@@ -13,7 +13,7 @@ class RD_Metabox {
 	public function rd_create_meta_boxes(){
 		add_meta_box(
       'form_identifier_box',
-      __('Identificador', $text_domain),
+      __('Identificador', $this->text_domain),
       array($this, 'form_identifier_box_content'),
       $this->plugin_prefix.'_integrations',
       'normal'
@@ -21,7 +21,7 @@ class RD_Metabox {
 
     add_meta_box(
       'token_rdstation_box',
-      __('Token RD Station', $text_domain),
+      __('Token RD Station', $this->text_domain),
       array($this, 'token_rdstation_box_content'),
       $this->plugin_prefix.'_integrations',
       'normal'
@@ -29,7 +29,7 @@ class RD_Metabox {
 
 	  add_meta_box(
       'form_id_box',
-      __('Qual formulário você deseja integrar ao RD Station?', $text_domain),
+      __('Qual formulário você deseja integrar ao RD Station?', $this->text_domain),
       array($this, 'form_id_box_content'),
       $this->plugin_prefix.'_integrations',
       'normal'
@@ -41,7 +41,7 @@ class RD_Metabox {
 	    $use_post_title = get_post_meta(get_the_ID(), 'use_post_title', true); ?>
 	    <input type="text" name="form_identifier" value="<?php echo $identifier; ?>">
 	    <span class="rd-integration-tips">
-				<?php _e('Esse identificador irá ajudar a saber o formulário de origem do lead.', $text_domain) ?>
+				<?php _e('Esse identificador irá ajudar a saber o formulário de origem do lead.', $this->text_domain) ?>
 			</span>
 	    <?php
 	}
@@ -50,7 +50,7 @@ class RD_Metabox {
 	    $token = get_post_meta(get_the_ID(), 'token_rdstation', true); ?>
 	    <input type="text" name="token_rdstation" size="32" value="<?php echo $token ?>">
 	    <span class="rd-integration-tips">
-				<?php _e('Não sabe seu token?', $text_domain) ?> <a href="https://app.rdstation.com.br/integracoes" target="blank"><?php _e('Clique aqui', $text_domain) ?></a></span>
+				<?php _e('Não sabe seu token?', $this->text_domain) ?> <a href="https://app.rdstation.com.br/integracoes" target="blank"><?php _e('Clique aqui', $this->text_domain) ?></a></span>
 	    <?php
 	}
 

--- a/metaboxes/add_custom_scripts.php
+++ b/metaboxes/add_custom_scripts.php
@@ -73,6 +73,8 @@ function rdscript_metaboxs($post) {
 
 //Add the meta box to post and page
 function rd_custom_script_meta_box() {
+  $text_domain = 'rdstation-wp';
+
 	add_meta_box(
     'rd_custom_script',
     __('Adicione scripts do RD Station', $text_domain),

--- a/metaboxes/add_custom_scripts.php
+++ b/metaboxes/add_custom_scripts.php
@@ -43,23 +43,53 @@ function rdscript_display_hook($content='') {
 //Displays a box that allows users to insert the scripts for the post or page
 function rdscript_metaboxs($post) {
   // Use nonce for verification
-  wp_nonce_field( plugin_basename( __FILE__ ), 'wpwox_noncename' );
-
+  wp_nonce_field( plugin_basename( __FILE__ ), 'rd_noncename' );
 	?>
-  <label for="rdscriptcontentinhead"><?php _e('&Aacute;rea para inser&ccedil;&atilde;o de scripts dentro da tag <strong>&lt;head&gt;</strong>','rdscript') ?></label><br />
-  <textarea style="width:100%; min-height: 50px;" id="rdscriptcontentinhead" name="rdscriptcontentinhead" /><?php echo html_entity_decode(get_post_meta($post->ID,'_rdscriptcontentinhead',true)); ?></textarea><br />
-  <label for="rdscriptcontentinfooter"><?php _e('&Aacute;rea para inser&ccedil;&atilde;o do script de integra&ccedil;&atilde;o de formul&aacute;rio <strong>antes do fechamento do &lt;/body&gt;</strong>','rdscript') ?></label><br />
-  <textarea style="width:100%; min-height: 150px;" id="rdscriptcontentinfooter" name="rdscriptcontentinfooter" /><?php echo html_entity_decode(get_post_meta($post->ID,'_rdscriptcontentinfooter',true)); ?></textarea>
+
+  <label for="rdscriptcontentinhead">
+    <?php _e('Área para inserção de scripts dentro da tag <strong><code>&lt;head&gt</code></strong>','rdstation-wp') ?>
+  </label>
+
+  <br/>
+
+  <textarea style="width:100%; min-height: 50px;" id="rdscriptcontentinhead" name="rdscriptcontentinhead" />
+    <?php echo html_entity_decode(get_post_meta($post->ID,'_rdscriptcontentinhead',true)); ?>
+  </textarea>
+
+  <br/>
+
+  <label for="rdscriptcontentinfooter">
+    <?php _e('Área para inserção do script de integração de formulário <strong>antes do fechamento do &lt;/body&gt;</strong>','rdstation-wp') ?>
+  </label>
+
+  <br/>
+
+  <textarea style="width:100%; min-height: 150px;" id="rdscriptcontentinfooter" name="rdscriptcontentinfooter" />
+    <?php echo html_entity_decode(get_post_meta($post->ID,'_rdscriptcontentinfooter',true)); ?>
+  </textarea>
 
   	<?php
 }
 
 //Add the meta box to post and page
-function wpwox_custom_script_meta_box() {
-	add_meta_box('wpwox_custom_script','Integra&ccedil;&atilde;o de scripts RD Station','rdscript_metaboxs','post','advanced');
-	add_meta_box('wpwox_custom_script','Integra&ccedil;&atilde;o de scripts RD Station','rdscript_metaboxs','page','advanced');
+function rd_custom_script_meta_box() {
+	add_meta_box(
+    'rd_custom_script',
+    __('Adicione scripts do RD Station', $text_domain),
+    'rdscript_metaboxs',
+    'post',
+    'advanced'
+  );
+
+	add_meta_box(
+    'rd_custom_script',
+    __('Adicione scripts do RD Station', $text_domain),
+    'rdscript_metaboxs',
+    'page',
+    'advanced'
+  );
 }
-add_action('admin_menu', 'wpwox_custom_script_meta_box');
+add_action('admin_menu', 'rd_custom_script_meta_box');
 
 // When the post is updating, save the script.
 
@@ -72,7 +102,7 @@ function rdscript_updates($pID) {
   // verify this came from the our screen and with proper authorization,
   // because save_post can be triggered at other times
 
-  if ( !wp_verify_nonce( $_POST['wpwox_noncename'], plugin_basename( __FILE__ ) ) )
+  if ( !wp_verify_nonce( $_POST['rd_noncename'], plugin_basename( __FILE__ ) ) )
       return;
 
 

--- a/metaboxes/rdcf7.php
+++ b/metaboxes/rdcf7.php
@@ -10,7 +10,7 @@
 		    $cf7Forms = get_posts( $args );
 
 		    if ( !$cf7Forms ) : ?>
-		    <p><?php _e('Não encontramos nenhum formulário cadastrado, entre no seu plugin de formulário de contato ou <a href="admin.php?page=wpcf7-new">clique aqui para criar um novo.</a>', parent::$text_domain) ?></p>
+		    <p><?php _e('Não encontramos nenhum formulário cadastrado, entre no seu plugin de formulário de contato ou <a href="admin.php?page=wpcf7-new">clique aqui para criar um novo.</a>', $this->text_domain) ?></p>
 		    <?php else : ?>
 		        <select name="form_id">
 		            <option value=""></option>

--- a/metaboxes/rdcf7.php
+++ b/metaboxes/rdcf7.php
@@ -10,7 +10,7 @@
 		    $cf7Forms = get_posts( $args );
 
 		    if ( !$cf7Forms ) : ?>
-		    <p><?php _e('Não encontramos nenhum formulário cadastrado, entre no seu plugin de formulário de contato ou <a href="admin.php?page=wpcf7-new">clique aqui para criar um novo.</a>', parent::$text_domain ?></p>
+		    <p><?php _e('Não encontramos nenhum formulário cadastrado, entre no seu plugin de formulário de contato ou <a href="admin.php?page=wpcf7-new">clique aqui para criar um novo.</a>', parent::$text_domain) ?></p>
 		    <?php else : ?>
 		        <select name="form_id">
 		            <option value=""></option>

--- a/metaboxes/rdcf7.php
+++ b/metaboxes/rdcf7.php
@@ -9,9 +9,9 @@
 		    $args = array('post_type' => 'wpcf7_contact_form', 'posts_per_page' => 100);
 		    $cf7Forms = get_posts( $args );
 
-		    if ( !$cf7Forms ) :
-		        echo '<p>Não encontramos nenhum formulário cadastrado, entre no seu plugin de formulário de contato ou <a href="admin.php?page=wpcf7-new">clique aqui para criar um novo.</a></p>';
-		    else : ?>
+		    if ( !$cf7Forms ) : ?>
+		    <p><?php _e('Não encontramos nenhum formulário cadastrado, entre no seu plugin de formulário de contato ou <a href="admin.php?page=wpcf7-new">clique aqui para criar um novo.</a>', parent::$text_domain ?></p>
+		    <?php else : ?>
 		        <select name="form_id">
 		            <option value=""></option>
 		                <?php

--- a/metaboxes/rdgf.php
+++ b/metaboxes/rdgf.php
@@ -5,43 +5,42 @@
 	class RDGF extends RD_Metabox {
 
 		function form_id_box_content(){
-		    $form_id = get_post_meta(get_the_ID(), 'form_id', true);
-		    $gForms = RGFormsModel::get_forms( null, 'title' );
-		    if( !$gForms ) :
-		        echo '<p>Não encontramos nenhum formulário cadastrado, entre no seu plugin de formulário de contato ou <a href="admin.php?page=gf_new_form">clique aqui para criar um novo.</a></p>';
-		    else : ?>
-		    	<div class="rd-select-form">
-			        <select name="form_id">
-			            <option value=""> </option>
-			            <?php
-			                foreach($gForms as $gForm){
-			                    echo "<option value=".$gForm->id.selected( $form_id, $gForm->id, false) .">".$gForm->title."</option>";
-			                }
-			            ?>
-			        </select>
-			    </div>
+	    $form_id = get_post_meta(get_the_ID(), 'form_id', true);
+	    $gForms = RGFormsModel::get_forms( null, 'title' );
+
+			if( !$gForms ) : ?>
+				<p><?php _e('Não encontramos nenhum formulário cadastrado, entre no seu plugin de formulário de contato ou <a href="admin.php?page=gf_new_form">clique aqui para criar um novo.</a>', parent::$text_domain) ?></p>
+		  <?php else : ?>
+				<div class="rd-select-form">
+					<select name="form_id">
+						<option value=""> </option>
+	            <?php
+                foreach($gForms as $gForm){
+                  echo "<option value=".$gForm->id.selected( $form_id, $gForm->id, false) .">".$gForm->title."</option>";
+                }
+	            ?>
+	        </select>
+		    </div>
 		    <?php
-		    	$gf_forms = GFAPI::get_forms();
+		    $gf_forms = GFAPI::get_forms();
 				$form_map = get_post_meta(get_the_ID(), 'gf_mapped_fields', true);
 
-		    	foreach ($gf_forms as $form) {
-		    		if ($form['id'] == $form_id) {
-		    			echo '<h4>Como os campos abaixo irão se chamar no RD Station?</h4>';
-			    		foreach ($form['fields'] as $field) {
-			    			if(!empty($form_map[$field['id']])){
-			    				$value = $form_map[$field['id']];
-			    			}
-			    			else {
-			    				$value = '';
-			    			}
-			    			echo '<p class="rd-fields-mapping"><span class="rd-fields-mapping-label">' . $field['label'] . '</span> <span class="dashicons dashicons-arrow-right-alt"></span> <input type="text" name="gf_mapped_fields['.$field['id'].']" value="'.$value.'">';
-			    		}
-			    	}
-		    	}
-
-		    endif;
+				foreach ($gf_forms as $form) {
+					if ($form['id'] == $form_id) { ?>
+						<h4><?php _e('Como os campos abaixo irão se chamar no RD Station?', parent::$text_domain) ?></h4>
+						<?php foreach ($form['fields'] as $field) {
+							if(!empty($form_map[$field['id']])){
+								$value = $form_map[$field['id']];
+							}
+							else {
+								$value = '';
+							}
+							echo '<p class="rd-fields-mapping"><span class="rd-fields-mapping-label">' . $field['label'] . '</span> <span class="dashicons dashicons-arrow-right-alt"></span> <input type="text" name="gf_mapped_fields['.$field['id'].']" value="'.$value.'">';
+						}
+					}
+				}
+			endif;
 		}
-
 	}
 
 ?>

--- a/metaboxes/rdgf.php
+++ b/metaboxes/rdgf.php
@@ -9,7 +9,7 @@
 	    $gForms = RGFormsModel::get_forms( null, 'title' );
 
 			if( !$gForms ) : ?>
-				<p><?php _e('Não encontramos nenhum formulário cadastrado, entre no seu plugin de formulário de contato ou <a href="admin.php?page=gf_new_form">clique aqui para criar um novo.</a>', parent::$text_domain) ?></p>
+				<p><?php _e('Não encontramos nenhum formulário cadastrado, entre no seu plugin de formulário de contato ou <a href="admin.php?page=gf_new_form">clique aqui para criar um novo.</a>', $this->text_domain) ?></p>
 		  <?php else : ?>
 				<div class="rd-select-form">
 					<select name="form_id">
@@ -27,7 +27,7 @@
 
 				foreach ($gf_forms as $form) {
 					if ($form['id'] == $form_id) { ?>
-						<h4><?php _e('Como os campos abaixo irão se chamar no RD Station?', parent::$text_domain) ?></h4>
+						<h4><?php _e('Como os campos abaixo irão se chamar no RD Station?', $this->text_domain) ?></h4>
 						<?php foreach ($form['fields'] as $field) {
 							if(!empty($form_map[$field['id']])){
 								$value = $form_map[$field['id']];

--- a/rd_custom_post_type.php
+++ b/rd_custom_post_type.php
@@ -15,24 +15,24 @@ class RDCustomPostType {
 
 	public function rd_custom_post_type() {
 	    $labels = array(
-	        'name'                  => __( 'Todas integrações: RD Station + ' . $this->acronym, $text_domain),
-	        'singular_name'         => __( 'Integração ' . $this->acronym, $text_domain ),
-	        'add_new'               => __( 'Criar integração', $text_domain ),
-	        'add_new_item'          => __( 'Criar Nova Integração', $text_domain ),
-	        'edit_item'             => __( 'Editar Integração', $text_domain ),
-	        'new_item'              => __( 'Nova Integração', $text_domain ),
-	        'all_items'             => __( 'Todas Integrações', $text_domain ),
-	        'view_item'             => __( 'Ver Integrações', $text_domain ),
-	        'search_items'          => __( 'Procurar Integrações', $text_domain ),
-	        'not_found'             => __( 'Nenhuma integração encontrada', $text_domain ),
-	        'not_found_in_trash'    => __( 'Nenhuma integração encontrada na lixeira', $text_domain ),
+	        'name'                  => __( 'Todas integrações: RD Station + ' . $this->acronym, $this->text_domain),
+	        'singular_name'         => __( 'Integração ' . $this->acronym, $this->text_domain ),
+	        'add_new'               => __( 'Criar integração', $this->text_domain ),
+	        'add_new_item'          => __( 'Criar Nova Integração', $this->text_domain ),
+	        'edit_item'             => __( 'Editar Integração', $this->text_domain ),
+	        'new_item'              => __( 'Nova Integração', $this->text_domain ),
+	        'all_items'             => __( 'Todas Integrações', $this->text_domain ),
+	        'view_item'             => __( 'Ver Integrações', $this->text_domain ),
+	        'search_items'          => __( 'Procurar Integrações', $this->text_domain ),
+	        'not_found'             => __( 'Nenhuma integração encontrada', $this->text_domain ),
+	        'not_found_in_trash'    => __( 'Nenhuma integração encontrada na lixeira', $this->text_domain ),
 	        'parent_item_colon'     => '',
 	        'menu_name'             => 'RD Station '.$this->acronym
 	    );
 
 	    $args = array(
 	        'labels'                => $labels,
-	        'description'           => __('Integração do ' . $this->name . ' com o RD Station', $text_domain),
+	        'description'           => __('Integração do ' . $this->name . ' com o RD Station', $this->text_domain),
 	        'public'                => true,
 	        'menu_position'         => 50,
 	        'supports'              => array( 'title' ),

--- a/rd_custom_post_type.php
+++ b/rd_custom_post_type.php
@@ -2,6 +2,8 @@
 
 class RDCustomPostType {
 
+  private $text_domain = 'rdstation-wp';
+
   public function __construct($slug) {
     $this->slug = $slug;
     require_once("metaboxes/$this->slug.php");
@@ -13,24 +15,24 @@ class RDCustomPostType {
 
 	public function rd_custom_post_type() {
 	    $labels = array(
-	        'name'                  => _x( 'Integrações '.$this->acronym, 'post_type_general_name' ),
-	        'singular_name'         => _x( 'Integração '.$this->acronym, 'post_type_singular_name' ),
-	        'add_new'               => _x( 'Criar integração', 'integration' ),
-	        'add_new_item'          => __( 'Criar Nova Integração' ),
-	        'edit_item'             => __( 'Editar Integração' ),
-	        'new_item'              => __( 'Nova Integração' ),
-	        'all_items'             => __( 'Todas Integrações' ),
-	        'view_item'             => __( 'Ver Integrações' ),
-	        'search_items'          => __( 'Procurar Integrações' ),
-	        'not_found'             => __( 'Nenhuma integração encontrada' ),
-	        'not_found_in_trash'    => __( 'Nenhuma integração encontrada na lixeira' ),
+	        'name'                  => __( 'Todas integrações: RD Station + ' . $this->acronym, $text_domain),
+	        'singular_name'         => __( 'Integração ' . $this->acronym, $text_domain ),
+	        'add_new'               => __( 'Criar integração', $text_domain ),
+	        'add_new_item'          => __( 'Criar Nova Integração', $text_domain ),
+	        'edit_item'             => __( 'Editar Integração', $text_domain ),
+	        'new_item'              => __( 'Nova Integração', $text_domain ),
+	        'all_items'             => __( 'Todas Integrações', $text_domain ),
+	        'view_item'             => __( 'Ver Integrações', $text_domain ),
+	        'search_items'          => __( 'Procurar Integrações', $text_domain ),
+	        'not_found'             => __( 'Nenhuma integração encontrada', $text_domain ),
+	        'not_found_in_trash'    => __( 'Nenhuma integração encontrada na lixeira', $text_domain ),
 	        'parent_item_colon'     => '',
 	        'menu_name'             => 'RD Station '.$this->acronym
 	    );
 
 	    $args = array(
 	        'labels'                => $labels,
-	        'description'           => 'Integração do '.$this->name.' com o RD Station',
+	        'description'           => __('Integração do ' . $this->name . ' com o RD Station', $text_domain),
 	        'public'                => true,
 	        'menu_position'         => 50,
 	        'supports'              => array( 'title' ),

--- a/rdstation-wp.php
+++ b/rdstation-wp.php
@@ -4,7 +4,7 @@
 Plugin Name: 	Integração RD Station
 Plugin URI: 	https://wordpress.org/plugins/integracao-rdstation
 Description:  Integre seus formulários de contato do WordPress com o RD Station
-Version:      3.1.1
+Version:      3.2
 Author:       Resultados Digitais
 Author URI:   http://resultadosdigitais.com.br
 License:      GPL2

--- a/rdstation-wp.php
+++ b/rdstation-wp.php
@@ -9,6 +9,7 @@ Author:       Resultados Digitais
 Author URI:   http://resultadosdigitais.com.br
 License:      GPL2
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+Text Domain:  rdstation-wp
 
 Integração RD Station is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/rdstation-wp.php
+++ b/rdstation-wp.php
@@ -4,7 +4,7 @@
 Plugin Name: 	Integração RD Station
 Plugin URI: 	https://wordpress.org/plugins/integracao-rdstation
 Description:  Integre seus formulários de contato do WordPress com o RD Station
-Version:      3.2
+Version:      3.2.2
 Author:       Resultados Digitais
 Author URI:   http://resultadosdigitais.com.br
 License:      GPL2

--- a/readme.txt
+++ b/readme.txt
@@ -55,6 +55,10 @@ https://github.com/ResultadosDigitais/rdstation-wp
 
 == Changelog ==
 
+= 3.2 =
+
+* Adição de chaves de internacionalização
+
 = 3.0 =
 
 * Integração com WooCommerce

--- a/settings/settings_fields.php
+++ b/settings/settings_fields.php
@@ -1,10 +1,13 @@
 <?php
 
 class RDSettingsFields {
+
+  private $text_domain = 'rdstation-wp';
+
   public function register_fields() {
     add_settings_field(
       'rd_public_token',
-      'Token Público',
+      __('Token Público', $text_domain),
       'rd_public_token_callback',
       'rdstation-settings-page',
       'rd_general_settings_section'
@@ -12,7 +15,7 @@ class RDSettingsFields {
 
     add_settings_field(
       'rd_private_token',
-      'Token Privado',
+      __('Token Privado', $text_domain),
       'rd_private_token_callback',
       'rdstation-settings-page',
       'rd_general_settings_section'
@@ -20,7 +23,7 @@ class RDSettingsFields {
 
     add_settings_field(
       'rd_woocommerce_conversion_identifier',
-      'Identificador das conversões de checkout',
+      __('Identificador das conversões de checkout', $text_domain),
       'rd_woocommerce_conversion_identifier_callback',
       'rdstation-settings-page',
       'rd_woocommerce_settings_section'

--- a/settings/settings_fields.php
+++ b/settings/settings_fields.php
@@ -7,7 +7,7 @@ class RDSettingsFields {
   public function register_fields() {
     add_settings_field(
       'rd_public_token',
-      __('Token Público', $text_domain),
+      __('Token Público', $this->text_domain),
       'rd_public_token_callback',
       'rdstation-settings-page',
       'rd_general_settings_section'
@@ -15,7 +15,7 @@ class RDSettingsFields {
 
     add_settings_field(
       'rd_private_token',
-      __('Token Privado', $text_domain),
+      __('Token Privado', $this->text_domain),
       'rd_private_token_callback',
       'rdstation-settings-page',
       'rd_general_settings_section'
@@ -23,7 +23,7 @@ class RDSettingsFields {
 
     add_settings_field(
       'rd_woocommerce_conversion_identifier',
-      __('Identificador das conversões de checkout', $text_domain),
+      __('Identificador das conversões de checkout', $this->text_domain),
       'rd_woocommerce_conversion_identifier_callback',
       'rdstation-settings-page',
       'rd_woocommerce_settings_section'

--- a/settings/settings_menu.php
+++ b/settings/settings_menu.php
@@ -1,10 +1,12 @@
 <?php
 
+$text_domain = 'rdstation-wp';
+
 add_action( 'admin_menu', 'rdstation_menu' );
 function rdstation_menu() {
   add_options_page(
-    'Configurações RD Station',
-    'Integração RD Station',
+    __('Configurações RD Station', $text_domain),
+    __('Integração RD Station', $text_domain),
     'manage_options',
     'rdstation-settings-page',
     'rdstation_settings_page_callback'

--- a/settings/settings_menu.php
+++ b/settings/settings_menu.php
@@ -1,9 +1,9 @@
 <?php
 
-$text_domain = 'rdstation-wp';
-
 add_action( 'admin_menu', 'rdstation_menu' );
 function rdstation_menu() {
+  $text_domain = 'rdstation-wp';
+
   add_options_page(
     __('Configurações RD Station', $text_domain),
     __('Integração RD Station', $text_domain),

--- a/settings/settings_sections.php
+++ b/settings/settings_sections.php
@@ -7,14 +7,14 @@ class RDSettingsSection {
   public function register_sections() {
     add_settings_section(
       'rd_general_settings_section',
-      __('Configurações Gerais', $text_domain),
+      __('Configurações Gerais', $this->text_domain),
       null,
       'rdstation-settings-page'
     );
 
     add_settings_section(
       'rd_woocommerce_settings_section',
-      __('Integração com WooCommerce', $text_domain),
+      __('Integração com WooCommerce', $this->text_domain),
       null,
       'rdstation-settings-page'
     );

--- a/settings/settings_sections.php
+++ b/settings/settings_sections.php
@@ -1,17 +1,20 @@
 <?php
 
 class RDSettingsSection {
+
+  private $text_domain = 'rdstation-wp';
+
   public function register_sections() {
     add_settings_section(
       'rd_general_settings_section',
-      'Configurações Gerais',
+      __('Configurações Gerais', $text_domain),
       null,
       'rdstation-settings-page'
     );
 
     add_settings_section(
       'rd_woocommerce_settings_section',
-      'Integração com WooCommerce',
+      __('Integração com WooCommerce', $text_domain),
       null,
       'rdstation-settings-page'
     );


### PR DESCRIPTION
# O que

O objetivo deste PR é preparar  o plugin para internacionalização, adicionando os métodos de internacionalização com os `text-domains` requeridos pelo WordPress.

# Cenários de teste

**Instalação do WP / Setup**

- Crie uma pasta para o projeto

- Dentro desta pasta, crie um arquivo chamado `docker-compose.yml` e cole o seguinte conteúdo desse gist: https://gist.github.com/filipenasc/7381a4880403133d5224fad353e0a102

- Rode `docker-compose up`, abra localhost:8000 e siga o processo normal de instalação.

- Você vai precisar instalar os seguintes plugins:
  - Contact Form 7
  - Gravity Forms
  - WooCommerce

## Contact Form 7

- [x] Clique no menu RD Station CF7 e vá na listagem de integrações, deve aparecer a seguinte mensagem: `Nenhuma integração encontrada`
- [x] A página de criar integração deve exibir os textos normalmente
- [x] A tela não deve quebrar em nenhuma situação

## Gravity Forms

- [x] Clique no menu RD Station GF e vá na listagem de integrações, deve aparecer a seguinte mensagem: `Nenhuma integração encontrada`
- [x] A página de criar integração deve exibir os textos normalmente
- [x] O mapeamento de campos deve funcionar normalmente
- [x] A tela não deve quebrar em nenhuma situação

## WooCommerce

- [x] Vá em Configurações -> Integração RD Station e verifique se os textos estão aparecendo normalmente na tela.

## Scripts

- [x] Crie ou edite uma página qualquer. Na parte inferior da tela de edição deve aparecer uma área para inserção de script do RD. Os textos devem ser exibidos normalmente.
- [x] Verifique as mesmas informações para algum **post** qualquer