### PR TITLE
[Gravity Forms] Bugfix hidden fields

### DIFF
--- a/integrations/gravity_forms/integration.php
+++ b/integrations/gravity_forms/integration.php
@@ -28,7 +28,7 @@ class RDGravityFormsIntegration extends LeadConversion {
   private function build_form_data($form_data) {
     $form_data = array_flip($form_data);
 
-    // Remove all fields that does not have an valid id
+    // Remove all fields that does not have a valid id
     $fields = array_filter($form_data, 'is_numeric');
 
     foreach ($fields as $value => $id) {

--- a/integrations/gravity_forms/integration.php
+++ b/integrations/gravity_forms/integration.php
@@ -1,33 +1,48 @@
 <?php
 
 class RDGravityFormsIntegration extends LeadConversion {
-  public function send_lead_conversion($entry, $gform){
 
-    $form_data = array_filter($entry);
+  const INTEGRATION_NAME = 'Plugin Gravity Forms';
 
-    foreach ($entry as $item => $value) {
-      if (is_numeric($item)) $this->form_data[$value] = $item;
+  public function send_lead_conversion($form_data, $gform) {
+    // Remove all empty values from $form_data
+    $form_data = array_filter($form_data);
+    $this->build_form_data($form_data);
+    $integrations = parent::get_forms('rdgf_integrations');
+
+    foreach ($integrations as $integration) {
+      $fields = get_post_meta($integration->ID, 'gf_mapped_fields', true);
+      $form_id = get_post_meta($integration->ID, 'form_id', true);
+
+      if ($form_id != $gform['id']) continue;
+
+      $this->field_mapping($fields);
+
+      parent::generate_static_fields($integration->ID, INTEGRATION_NAME);
+      parent::conversion($this->form_data);
     }
+  }
 
-    $forms = parent::get_forms('rdgf_integrations');
+  private function build_form_data($form_data) {
+    $form_data = array_flip($form_data);
 
-    foreach ($forms as $form) {
-      $fields = get_post_meta($form->ID, 'gf_mapped_fields', true);
-      $form_id = get_post_meta($form->ID, 'form_id', true);
+    // Remove all fields that does not have an valid id
+    $fields = array_filter($form_data, 'is_numeric');
 
-      if ( $form_id == $gform['id'] ) {
-        foreach ($this->form_data as $key => $value) {
-          if($fields[$value] != null && !empty($fields[$value])) {
-            $this->form_data[$key] = $fields[$value];
-          }
-          else {
-            unset($this->form_data[$key]);
-          }
-        }
-        $this->form_data = array_flip($this->form_data);
-        parent::generate_static_fields($form->ID, 'Plugin Gravity Forms');
-        parent::conversion($this->form_data);
+    foreach ($fields as $value => $id) {
+      $this->form_data[$id] = $value;
+    }
+  }
+
+  private function field_mapping($fields) {
+    foreach ($this->form_data as $field_id => $field_value) {
+      $field_name = $fields[$field_id];
+
+      if(!empty($field_name)) {
+        $this->form_data[$field_name] = $field_value;
       }
+
+      unset($this->form_data[$field_id]);
     }
   }
 }

--- a/integrations/gravity_forms/integration.php
+++ b/integrations/gravity_forms/integration.php
@@ -2,13 +2,15 @@
 
 class RDGravityFormsIntegration extends LeadConversion {
 
+  const POST_TYPE        = 'rdgf_integrations';
   const INTEGRATION_NAME = 'Plugin Gravity Forms';
 
   public function send_lead_conversion($form_data, $gform) {
     // Remove all empty values from $form_data
     $form_data = array_filter($form_data);
     $this->build_form_data($form_data);
-    $integrations = parent::get_forms('rdgf_integrations');
+
+    $integrations = parent::get_forms(self::POST_TYPE);
 
     foreach ($integrations as $integration) {
       $fields = get_post_meta($integration->ID, 'gf_mapped_fields', true);
@@ -18,7 +20,7 @@ class RDGravityFormsIntegration extends LeadConversion {
 
       $this->field_mapping($fields);
 
-      parent::generate_static_fields($integration->ID, INTEGRATION_NAME);
+      parent::generate_static_fields($integration->ID, self::INTEGRATION_NAME);
       parent::conversion($this->form_data);
     }
   }

--- a/integrations/gravity_forms/integration.php
+++ b/integrations/gravity_forms/integration.php
@@ -3,6 +3,8 @@
 class RDGravityFormsIntegration extends LeadConversion {
   public function send_lead_conversion($entry, $gform){
 
+    $form_data = array_filter($entry);
+
     foreach ($entry as $item => $value) {
       if (is_numeric($item)) $this->form_data[$value] = $item;
     }


### PR DESCRIPTION
# O que

Correção de um bug no mapeamento Gravity Forms e algumas melhorias na legibilidade do código.

O mapeamento do Gravity Forms não validava os hidden fields em branco, isso fazia que um hidden field com o mesmo nome de um input normal acabasse sobrescrevendo o valor na hora da integração.

# Como testar

- Crie um formulário no Gravity Forms, e crie um campo com as opções "Segunda" e "Terça".
- Crie uma condicional: se o usuário preencher "Segunda", mostre um campo para preencher, se ele selecionar "Terça", mostre outro.
- Crie uma integração mapeando todos estes campos.
- [ ] Ao preencher o formulário, todos campos devem ir normalmente para o RD Station.