### PR TITLE
Change default language

### DIFF
--- a/integracao-rd-station.php
+++ b/integracao-rd-station.php
@@ -4,7 +4,7 @@
 Plugin Name: 	Integração RD Station
 Plugin URI: 	https://wordpress.org/plugins/integracao-rdstation
 Description:  Integre seus formulários de contato do WordPress com o RD Station
-Version:      3.2.2
+Version:      3.2.3
 Author:       Resultados Digitais
 Author URI:   http://resultadosdigitais.com.br
 License:      GPL2

--- a/metaboxes/RD_Metabox.php
+++ b/metaboxes/RD_Metabox.php
@@ -38,7 +38,7 @@ class RD_Metabox {
 	    $use_post_title = get_post_meta(get_the_ID(), 'use_post_title', true); ?>
 	    <input type="text" name="form_identifier" value="<?php echo $identifier; ?>">
 	    <span class="rd-integration-tips">
-				<?php _e('This identifier will help you identify the Lead source.', 'integracao-rd-station') ?>
+				<?php _e('This identifier will help you to identify the Lead source.', 'integracao-rd-station') ?>
 			</span>
 	    <?php
 	}
@@ -47,7 +47,7 @@ class RD_Metabox {
 	    $token = get_post_meta(get_the_ID(), 'token_rdstation', true); ?>
 	    <input type="text" name="token_rdstation" size="32" value="<?php echo $token ?>">
 	    <span class="rd-integration-tips">
-				<?php _e("Don't know your token?", 'integracao-rd-station') ?> <a href="https://app.rdstation.com.br/integracoes" target="blank"><?php _e('Click here', 'integracao-rd-station') ?></a></span>
+				<a href="https://app.rdstation.com.br/integracoes" target="blank"><?php _e('Click here to get your token', 'integracao-rd-station') ?></a></span>
 	    <?php
 	}
 

--- a/metaboxes/RD_Metabox.php
+++ b/metaboxes/RD_Metabox.php
@@ -10,7 +10,7 @@ class RD_Metabox {
 	public function rd_create_meta_boxes(){
 		add_meta_box(
       'form_identifier_box',
-      __('Identificador', 'integracao-rd-station'),
+      __('Conversion identifier', 'integracao-rd-station'),
       array($this, 'form_identifier_box_content'),
       $this->plugin_prefix.'_integrations',
       'normal'
@@ -18,7 +18,7 @@ class RD_Metabox {
 
     add_meta_box(
       'token_rdstation_box',
-      __('Token RD Station', 'integracao-rd-station'),
+      __('RD Station Token', 'integracao-rd-station'),
       array($this, 'token_rdstation_box_content'),
       $this->plugin_prefix.'_integrations',
       'normal'
@@ -26,7 +26,7 @@ class RD_Metabox {
 
 	  add_meta_box(
       'form_id_box',
-      __('Qual formulário você deseja integrar ao RD Station?', 'integracao-rd-station'),
+      __('Select a form to integrate with RD Station', 'integracao-rd-station'),
       array($this, 'form_id_box_content'),
       $this->plugin_prefix.'_integrations',
       'normal'
@@ -38,7 +38,7 @@ class RD_Metabox {
 	    $use_post_title = get_post_meta(get_the_ID(), 'use_post_title', true); ?>
 	    <input type="text" name="form_identifier" value="<?php echo $identifier; ?>">
 	    <span class="rd-integration-tips">
-				<?php _e('Esse identificador irá ajudar a saber o formulário de origem do lead.', 'integracao-rd-station') ?>
+				<?php _e('This identifier will help you identify the Lead source.', 'integracao-rd-station') ?>
 			</span>
 	    <?php
 	}
@@ -47,7 +47,7 @@ class RD_Metabox {
 	    $token = get_post_meta(get_the_ID(), 'token_rdstation', true); ?>
 	    <input type="text" name="token_rdstation" size="32" value="<?php echo $token ?>">
 	    <span class="rd-integration-tips">
-				<?php _e('Não sabe seu token?', 'integracao-rd-station') ?> <a href="https://app.rdstation.com.br/integracoes" target="blank"><?php _e('Clique aqui', 'integracao-rd-station') ?></a></span>
+				<?php _e("Don't know your token?", 'integracao-rd-station') ?> <a href="https://app.rdstation.com.br/integracoes" target="blank"><?php _e('Click here', 'integracao-rd-station') ?></a></span>
 	    <?php
 	}
 

--- a/metaboxes/add_custom_scripts.php
+++ b/metaboxes/add_custom_scripts.php
@@ -47,7 +47,7 @@ function rdscript_metaboxs($post) {
 	?>
 
   <label for="rdscriptcontentinhead">
-    <?php _e('Área para inserção de scripts dentro da tag <strong><code>&lt;head&gt</code></strong>','integracao-rd-station') ?>
+    <?php _e('Scripts added here will be added inside the <strong><code>&lt;head&gt</code> tag</strong>','integracao-rd-station') ?>
   </label>
 
   <br/>
@@ -59,7 +59,7 @@ function rdscript_metaboxs($post) {
   <br/>
 
   <label for="rdscriptcontentinfooter">
-    <?php _e('Área para inserção do script de integração de formulário <strong>antes do fechamento do &lt;/body&gt;</strong>','integracao-rd-station') ?>
+    <?php _e('Scripts added here will be added <strong>before closing &lt;/body&gt; tag</strong>','integracao-rd-station') ?>
   </label>
 
   <br/>
@@ -75,7 +75,7 @@ function rdscript_metaboxs($post) {
 function rd_custom_script_meta_box() {
 	add_meta_box(
     'rd_custom_script',
-    __('Adicione scripts do RD Station', 'integracao-rd-station'),
+    __('Add RD Station scripts', 'integracao-rd-station'),
     'rdscript_metaboxs',
     'post',
     'advanced'
@@ -83,7 +83,7 @@ function rd_custom_script_meta_box() {
 
 	add_meta_box(
     'rd_custom_script',
-    __('Adicione scripts do RD Station', 'integracao-rd-station'),
+    __('Add RD Station scripts', 'integracao-rd-station'),
     'rdscript_metaboxs',
     'page',
     'advanced'

--- a/metaboxes/add_custom_scripts.php
+++ b/metaboxes/add_custom_scripts.php
@@ -47,7 +47,7 @@ function rdscript_metaboxs($post) {
 	?>
 
   <label for="rdscriptcontentinhead">
-    <?php _e('Scripts added here will be added inside the <strong><code>&lt;head&gt</code> tag</strong>','integracao-rd-station') ?>
+    <?php _e('Scripts added here will be inserted inside the <strong><code>&lt;head&gt</code> tag</strong>','integracao-rd-station') ?>
   </label>
 
   <br/>
@@ -59,7 +59,7 @@ function rdscript_metaboxs($post) {
   <br/>
 
   <label for="rdscriptcontentinfooter">
-    <?php _e('Scripts added here will be added <strong>before closing &lt;/body&gt; tag</strong>','integracao-rd-station') ?>
+    <?php _e('Scripts added here will be inserted <strong>before closing &lt;/body&gt; tag</strong>','integracao-rd-station') ?>
   </label>
 
   <br/>

--- a/metaboxes/rdcf7.php
+++ b/metaboxes/rdcf7.php
@@ -10,7 +10,7 @@
 		    $cf7Forms = get_posts( $args );
 
 		    if ( !$cf7Forms ) : ?>
-		    <p><?php _e("There's no form created. <a href='admin.php?page=wpcf7-new'>Click here to create a new one.</a>", 'integracao-rd-station')?></p>
+		    <p><?php _e("No forms have been found. <a href='admin.php?page=wpcf7-new'>Click here to create a new one.</a>", 'integracao-rd-station')?></p>
 		    <?php else : ?>
 		        <select name="form_id">
 		            <option value=""></option>

--- a/metaboxes/rdcf7.php
+++ b/metaboxes/rdcf7.php
@@ -10,7 +10,7 @@
 		    $cf7Forms = get_posts( $args );
 
 		    if ( !$cf7Forms ) : ?>
-		    <p><?php _e('Não encontramos nenhum formulário cadastrado, entre no seu plugin de formulário de contato ou <a href="admin.php?page=wpcf7-new">clique aqui para criar um novo.</a>', 'integracao-rd-station') ?></p>
+		    <p><?php _e("There's no form created. <a href='admin.php?page=wpcf7-new'>Click here to create a new one.</a>", 'integracao-rd-station')?></p>
 		    <?php else : ?>
 		        <select name="form_id">
 		            <option value=""></option>

--- a/metaboxes/rdgf.php
+++ b/metaboxes/rdgf.php
@@ -9,7 +9,7 @@
 	    $gForms = RGFormsModel::get_forms( null, 'title' );
 
 			if( !$gForms ) : ?>
-				<p><?php _e('Não encontramos nenhum formulário cadastrado, entre no seu plugin de formulário de contato ou <a href="admin.php?page=gf_new_form">clique aqui para criar um novo.</a>', 'integracao-rd-station') ?></p>
+				<p><?php _e("There's no form created. <a href='admin.php?page=gf_new_form'>Click here to create a new one.</a>", 'integracao-rd-station')?></p>
 		  <?php else : ?>
 				<div class="rd-select-form">
 					<select name="form_id">
@@ -27,7 +27,7 @@
 
 				foreach ($gf_forms as $form) {
 					if ($form['id'] == $form_id) { ?>
-						<h4><?php _e('Como os campos abaixo irão se chamar no RD Station?', 'integracao-rd-station') ?></h4>
+						<h4><?php _e('Map the fields below according to their names on RD Station.', 'integracao-rd-station') ?></h4>
 						<?php foreach ($form['fields'] as $field) {
 							if(!empty($form_map[$field['id']])){
 								$value = $form_map[$field['id']];

--- a/metaboxes/rdgf.php
+++ b/metaboxes/rdgf.php
@@ -9,7 +9,7 @@
 	    $gForms = RGFormsModel::get_forms( null, 'title' );
 
 			if( !$gForms ) : ?>
-				<p><?php _e("There's no form created. <a href='admin.php?page=gf_new_form'>Click here to create a new one.</a>", 'integracao-rd-station')?></p>
+				<p><?php _e("No forms have been found. <a href='admin.php?page=gf_new_form'>Click here to create a new one.</a>", 'integracao-rd-station')?></p>
 		  <?php else : ?>
 				<div class="rd-select-form">
 					<select name="form_id">
@@ -27,7 +27,7 @@
 
 				foreach ($gf_forms as $form) {
 					if ($form['id'] == $form_id) { ?>
-						<h4><?php _e('Map the fields below according to their names on RD Station.', 'integracao-rd-station') ?></h4>
+						<h4><?php _e('Map the fields below according to their names in RD Station.', 'integracao-rd-station') ?></h4>
 						<?php foreach ($form['fields'] as $field) {
 							if(!empty($form_map[$field['id']])){
 								$value = $form_map[$field['id']];

--- a/rd_custom_post_type.php
+++ b/rd_custom_post_type.php
@@ -12,24 +12,24 @@ class RDCustomPostType {
 
 	public function rd_custom_post_type() {
 	    $labels = array(
-	        'name'                  => __( 'Todas integrações: RD Station + ' . $this->acronym, 'integracao-rd-station'),
-	        'singular_name'         => __( 'Integração ' . $this->acronym, 'integracao-rd-station' ),
-	        'add_new'               => __( 'Criar integração', 'integracao-rd-station' ),
-	        'add_new_item'          => __( 'Criar Nova Integração', 'integracao-rd-station' ),
-	        'edit_item'             => __( 'Editar Integração', 'integracao-rd-station' ),
-	        'new_item'              => __( 'Nova Integração', 'integracao-rd-station' ),
-	        'all_items'             => __( 'Todas Integrações', 'integracao-rd-station' ),
-	        'view_item'             => __( 'Ver Integrações', 'integracao-rd-station' ),
-	        'search_items'          => __( 'Procurar Integrações', 'integracao-rd-station' ),
-	        'not_found'             => __( 'Nenhuma integração encontrada', 'integracao-rd-station' ),
-	        'not_found_in_trash'    => __( 'Nenhuma integração encontrada na lixeira', 'integracao-rd-station' ),
+	        'name'                  => __( 'All integrations: RD Station + ' . $this->acronym, 'integracao-rd-station'),
+	        'singular_name'         => __( 'Integration ' . $this->acronym, 'integracao-rd-station' ),
+	        'add_new'               => __( 'Create integration', 'integracao-rd-station' ),
+	        'add_new_item'          => __( 'Create new integration', 'integracao-rd-station' ),
+	        'edit_item'             => __( 'Edit integration', 'integracao-rd-station' ),
+	        'new_item'              => __( 'New integration', 'integracao-rd-station' ),
+	        'all_items'             => __( 'All integrations', 'integracao-rd-station' ),
+	        'view_item'             => __( 'View integrations', 'integracao-rd-station' ),
+	        'search_items'          => __( 'Search integrations', 'integracao-rd-station' ),
+	        'not_found'             => __( 'No integration found', 'integracao-rd-station' ),
+	        'not_found_in_trash'    => __( 'No integration found in the trash', 'integracao-rd-station' ),
 	        'parent_item_colon'     => '',
 	        'menu_name'             => 'RD Station '.$this->acronym
 	    );
 
 	    $args = array(
 	        'labels'                => $labels,
-	        'description'           => __('Integração do ' . $this->name . ' com o RD Station', 'integracao-rd-station'),
+	        'description'           => __('Integration of ' . $this->name . ' with RD Station', 'integracao-rd-station'),
 	        'public'                => true,
 	        'menu_position'         => 50,
 	        'supports'              => array( 'title' ),

--- a/settings/settings_fields.php
+++ b/settings/settings_fields.php
@@ -4,7 +4,7 @@ class RDSettingsFields {
   public function register_fields() {
     add_settings_field(
       'rd_public_token',
-      __('Token Público', 'integracao-rd-station'),
+      __('Public Token', 'integracao-rd-station'),
       'rd_public_token_callback',
       'rdstation-settings-page',
       'rd_general_settings_section'
@@ -12,7 +12,7 @@ class RDSettingsFields {
 
     add_settings_field(
       'rd_private_token',
-      __('Token Privado', 'integracao-rd-station'),
+      __('Private Token', 'integracao-rd-station'),
       'rd_private_token_callback',
       'rdstation-settings-page',
       'rd_general_settings_section'
@@ -20,7 +20,7 @@ class RDSettingsFields {
 
     add_settings_field(
       'rd_woocommerce_conversion_identifier',
-      __('Identificador das conversões de checkout', 'integracao-rd-station'),
+      __('Identifier from checkout conversions', 'integracao-rd-station'),
       'rd_woocommerce_conversion_identifier_callback',
       'rdstation-settings-page',
       'rd_woocommerce_settings_section'

--- a/settings/settings_menu.php
+++ b/settings/settings_menu.php
@@ -3,8 +3,8 @@
 add_action( 'admin_menu', 'rdstation_menu' );
 function rdstation_menu() {
   add_options_page(
-    __('Configurações RD Station', 'integracao-rd-station'),
-    __('Integração RD Station', 'integracao-rd-station'),
+    __('RD Station Settings', 'integracao-rd-station'),
+    __('RD Station Integration', 'integracao-rd-station'),
     'manage_options',
     'rdstation-settings-page',
     'rdstation_settings_page_callback'

--- a/settings/settings_sections.php
+++ b/settings/settings_sections.php
@@ -4,14 +4,14 @@ class RDSettingsSection {
   public function register_sections() {
     add_settings_section(
       'rd_general_settings_section',
-      __('Configurações Gerais', 'integracao-rd-station'),
+      __('General Settings', 'integracao-rd-station'),
       null,
       'rdstation-settings-page'
     );
 
     add_settings_section(
       'rd_woocommerce_settings_section',
-      __('Integração com WooCommerce', 'integracao-rd-station'),
+      __('WooCommerce Integration', 'integracao-rd-station'),
       null,
       'rdstation-settings-page'
     );


### PR DESCRIPTION
It changes the default language from pt-br to en-us.

Motivation: WordPress translation system does not have an option to add an en-us translation.

**Testing: check the texts on the following parts of plugin**

Contact Form 7

- [x] Menu options
- [x] Setup page without any form created
- [x] Creation of a new integration

Gravity Forms

- [x] Menu options
- [x] Setup page without any form created
- [x] Creation of a new integration

WooCommerce

- [x] Setup page

Scripts

- [x] Area for insert scripts on **posts** and **pages**