### PR TITLE
Adicionar campos a serem ignorados na conversão.

### DIFF
--- a/integracao-rd-station.php
+++ b/integracao-rd-station.php
@@ -4,7 +4,7 @@
 Plugin Name: 	Integração RD Station
 Plugin URI: 	https://wordpress.org/plugins/integracao-rdstation
 Description:  Integre seus formulários de contato do WordPress com o RD Station
-Version:      3.2.4
+Version:      3.2.5
 Author:       Resultados Digitais
 Author URI:   http://resultadosdigitais.com.br
 License:      GPL2

--- a/integracao-rd-station.php
+++ b/integracao-rd-station.php
@@ -4,7 +4,7 @@
 Plugin Name: 	Integração RD Station
 Plugin URI: 	https://wordpress.org/plugins/integracao-rdstation
 Description:  Integre seus formulários de contato do WordPress com o RD Station
-Version:      3.2.3
+Version:      3.2.4
 Author:       Resultados Digitais
 Author URI:   http://resultadosdigitais.com.br
 License:      GPL2

--- a/lead-conversion.php
+++ b/lead-conversion.php
@@ -61,7 +61,15 @@ class LeadConversion {
         'your-email',
         'e-mail',
         'mail',
-        'cielo_debit_number'
+        'cielo_debit_number',
+        'cielo_debit_holder_name',
+        'cielo_debit_expiry',
+        'cielo_debit_cvc',
+        'cielo_credit_number',
+        'cielo_credit_holder_name',
+        'cielo_credit_expiry',
+        'cielo_credit_cvc',
+        'cielo_credit_installments'
       ), $form_data
     );
 

--- a/lead-conversion.php
+++ b/lead-conversion.php
@@ -61,6 +61,7 @@ class LeadConversion {
         'your-email',
         'e-mail',
         'mail',
+        'cielo_debit_number'
       ), $form_data
     );
 


### PR DESCRIPTION
Adicionados campos com dados sensíveis a serem ignorados, provindos do plugin da Cielo.

Para testar configurar plugin e enviar dados de conversão com os atributos nos campos abaixo:

```
'cielo_debit_number',
'cielo_debit_holder_name',
'cielo_debit_expiry',
'cielo_debit_cvc',
'cielo_credit_number',
'cielo_credit_holder_name',
'cielo_credit_expiry',
'cielo_credit_cvc',
'cielo_credit_installments'
```
