### PR TITLE
Fix function return value in write context

### DIFF
--- a/includes/events/rdsm_admin_initialized.php
+++ b/includes/events/rdsm_admin_initialized.php
@@ -15,8 +15,9 @@ class RDSMAdminInitialized implements RDSMEventsInterface {
 
   public function admin_init_hooks() {
     initialize_rdstation_settings_page();
+    $base_migrated = get_option('rdsm_base_migrated');
 
-    if (empty(get_option('rdsm_base_migrated'))) {
+    if (empty($base_migrated)) {
       $this->migrate_legacy_woocoommerce_identifier();
       $this->migrate_legacy_tokens();
       update_option('rdsm_base_migrated', true);

--- a/integracao-rd-station.php
+++ b/integracao-rd-station.php
@@ -4,7 +4,7 @@
 Plugin Name: 	Integração RD Station
 Plugin URI: 	https://wordpress.org/plugins/integracao-rdstation
 Description:  Integre seus formulários de contato do WordPress com o RD Station
-Version:      4.0.1
+Version:      4.0.2
 Author:       RD Station
 Author URI:   https://www.rdstation.com/
 License:      GPL2


### PR DESCRIPTION
Fix this error: `Fatal error: Can't use function return value in write context in /var/www/html/my-website/web/wp-content/plugins/integracao-rd-station/includes/events/rdsm_admin_initialized.php on line 19`

This error occurs because the `empty()` method does not accept functions as arguments in some PHP versions, even if those functions return valid values such as `strings`, `bool` and `integer`.

Solution: moving the function result to a variable.