### PR TITLE
Allow tracking code on all site pages

### DIFF
--- a/includes/events/rdsm_site_initialized.php
+++ b/includes/events/rdsm_site_initialized.php
@@ -17,7 +17,7 @@ class RDSMSiteInitialized implements RDSMEventsInterface {
     $tracking_code = get_option('rdsm_tracking_code');
 
     if (!empty($tracking_code)) {
-      if (is_home() || is_single() || is_page()) {
+      if (!is_admin()) {
         echo html_entity_decode($this->tracking_code_script_tag($tracking_code));
 
         return true;

--- a/integracao-rd-station.php
+++ b/integracao-rd-station.php
@@ -4,7 +4,7 @@
 Plugin Name: 	Integração RD Station
 Plugin URI: 	https://wordpress.org/plugins/integracao-rdstation
 Description:  Integre seus formulários de contato do WordPress com o RD Station
-Version:      4.0.2
+Version:      4.0.3
 Author:       RD Station
 Author URI:   https://www.rdstation.com/
 License:      GPL2


### PR DESCRIPTION
# What?
This PR removes the lock to only show the tracking code on some pages. We have some types of pages no mapped that our clients use and its normal on WordPress ecosystem.

# Why?
We received two ticket about the Tracking Code not working on specific pages. When was investigating we notice that the pages where the tracking code is not working have the type `archive`.