### PR TITLE
Block card info from erede

### DIFF
--- a/includes/resources/rdsm_conversion.php
+++ b/includes/resources/rdsm_conversion.php
@@ -33,7 +33,15 @@ class RDSMConversion {
     'rede_credit_holder_name',
     'rede_credit_expiry',
     'rede_credit_cvc',
-    'rede_credit_installments'
+    'rede_credit_installments',
+    'erede_api',
+    'erede_api_cvv',
+    'erede_api_validade',
+    'erede_api_titular',
+    'erede_api_devicefingerprintid',
+    'erede_api_bandeira',
+    'erede_api_fiscal',
+    'erede_api_parcela'
   );
 
   public $payload;

--- a/integracao-rd-station.php
+++ b/integracao-rd-station.php
@@ -4,7 +4,7 @@
 Plugin Name: 	Integração RD Station
 Plugin URI: 	https://wordpress.org/plugins/integracao-rdstation
 Description:  Integre seus formulários de contato do WordPress com o RD Station
-Version:      4.0.6
+Version:      4.0.7
 Author:       RD Station
 Author URI:   https://www.rdstation.com/
 License:      GPL2


### PR DESCRIPTION
The goal of this PR is blocking credit card info coming from `erede`. We already have a mechanism to block credit card numbers, but by adding `erede` to our ignored_fields list will also block other info, like cvv.