### PR TITLE
Persist data wp

### DIFF
--- a/integracao-rd-station/assets/js/custom_fields.js
+++ b/integracao-rd-station/assets/js/custom_fields.js
@@ -2,12 +2,8 @@ function RDSMCustomFields() {
   
   this.formsSelectChanged = function() {
     var selectedForm = document.getElementById("forms_select");
-    var type = "wpcf7";
-    var post_id = document.getElementById("post_id").innerHTML;
-    
-    if (selectedForm.classList.contains('wpgf')) {
-      type = "wpgf";
-    }
+    var type = selectedForm.dataset.integrationType;
+    var post_id = selectedForm.dataset.postId;
 
     getCustomFieldsByFormId(selectedForm.value, type, post_id);
     selectedForm.onchange = function() {
@@ -20,38 +16,41 @@ function RDSMCustomFields() {
       url: ajaxurl,
       method: 'POST',
       data: { action: 'rdsm-custom-fields', form_id: form_id, type: type, post_id: post_id },
-      success: function(data) {  
-        var html = "";
-        var select = "";
-
-        for (i = 0; i < data["select_items"].length; i++) {
-          select += "<option value=" + data["select_items"][i]["value"] + ">" + data["select_items"][i]["value"] + "</option>";
-        }
-
-        if (type == "wpcf7") {
-          document.getElementById("custom_fields").innerHTML = getCF7HTML(data, select);
-        }else {
-          document.getElementById("custom_fields").innerHTML = getGFHTML(data, select);
-          setSelectedItems(data);
-        }
+      success: function(data) {
+        renderFieldMapping(data, type);
       }
     });
   }
 
-  function getCF7HTML(data, select) {
+  function renderFieldMapping(fieldMapping, type) {
+    var select = "";
+
+    for (i = 0; i < fieldMapping["select_items"].length; i++) {
+      select += "<option value=" + fieldMapping["select_items"][i]["value"] + ">" + fieldMapping["select_items"][i]["value"] + "</option>";
+    }
+
+    if (type == "contact_form_7") {
+      document.getElementById("custom_fields").innerHTML = getContactForm7HTML(fieldMapping, select);
+    }else if (type == "gravity_forms") {
+      document.getElementById("custom_fields").innerHTML = getGravityFormHTML(fieldMapping, select);
+      setSelectedItems(fieldMapping);
+    }
+  }
+
+  function getContactForm7HTML(data, select) {
     var html = "";
-    for (i = 0; i < data["fields_cf7"].length; i++) {
-      html += "<p class=\"rd-fields-mapping\"><span class=\"rd-fields-mapping-label\">" + data["fields_cf7"][i] + 
-              "</span> <span class=\"dashicons dashicons-arrow-right-alt\"></span><select name=\"gf_mapped_fields["+data["fields_cf7"][i]+"]\"><option value=\"\"></option>" + select + "</select></p>";          
+    for (i = 0; i < data["fields_contact_form_7"].length; i++) {
+      html += "<p class=\"rd-fields-mapping\"><span class=\"rd-fields-mapping-label\">" + data["fields_contact_form_7"][i] + 
+              "</span> <span class=\"dashicons dashicons-arrow-right-alt\"></span><select name=\"gf_mapped_fields["+data["fields_contact_form_7"][i]+"]\"><option value=\"\"></option>" + select + "</select></p>";          
     }
     return html;
   }
 
-  function getGFHTML(data, select) {
+  function getGravityFormHTML(data, select) {
     var html = "";
-    for (i = 0; i < data["fields_gf"].length; i++) {
-      html += "<p class=\"rd-fields-mapping\"><span class=\"rd-fields-mapping-label\">" + data["fields_gf"][i]["label"] + 
-              "</span> <span class=\"dashicons dashicons-arrow-right-alt\"></span><select name=\"gf_mapped_fields["+data["fields_gf"][i]["id"]+"]\"><option value=\"\"></option>" + select + "</select></p>";
+    for (i = 0; i < data["fields_gravity_forms"].length; i++) {
+      html += "<p class=\"rd-fields-mapping\"><span class=\"rd-fields-mapping-label\">" + data["fields_gravity_forms"][i]["label"] + 
+              "</span> <span class=\"dashicons dashicons-arrow-right-alt\"></span><select name=\"gf_mapped_fields["+data["fields_gravity_forms"][i]["id"]+"]\"><option value=\"\"></option>" + select + "</select></p>";
     }
     return html;
   }

--- a/integracao-rd-station/assets/js/custom_fields.js
+++ b/integracao-rd-station/assets/js/custom_fields.js
@@ -17,48 +17,42 @@ function RDSMCustomFields() {
       method: 'POST',
       data: { action: 'rdsm-custom-fields', form_id: form_id, type: type, post_id: post_id },
       success: function(data) {
-        renderFieldMapping(data, type);
+        renderFieldMapping(data, type, form_id);
       }
     });
   }
 
-  function renderFieldMapping(fieldMapping, type) {
+  function renderFieldMapping(fieldMapping, type, form_id) {
     var select = "";
 
     for (i = 0; i < fieldMapping["select_items"].length; i++) {
-      select += "<option value=" + fieldMapping["select_items"][i]["value"] + ">" + fieldMapping["select_items"][i]["value"] + "</option>";
+      select += "<option value=" + fieldMapping["select_items"][i]["api_identifier"] + ">" + fieldMapping["select_items"][i]["value"] + "</option>";
     }
 
     if (type == "contact_form_7") {
-      document.getElementById("custom_fields").innerHTML = getContactForm7HTML(fieldMapping, select);
+      document.getElementById("custom_fields").innerHTML = getIntegrationFormHTML(fieldMapping, select, type, "cf7", form_id);
+      setSelectedItems(fieldMapping, type, "cf7", form_id);
     }else if (type == "gravity_forms") {
-      document.getElementById("custom_fields").innerHTML = getGravityFormHTML(fieldMapping, select);
-      setSelectedItems(fieldMapping);
+      document.getElementById("custom_fields").innerHTML = getIntegrationFormHTML(fieldMapping, select, type, "gf", form_id);
+      setSelectedItems(fieldMapping, type, "gf", form_id);
     }
   }
 
-  function getContactForm7HTML(data, select) {
+  function getIntegrationFormHTML(data, select, integrationType, initials, form_id) {
     var html = "";
-    for (i = 0; i < data["fields_contact_form_7"].length; i++) {
-      html += "<p class=\"rd-fields-mapping\"><span class=\"rd-fields-mapping-label\">" + data["fields_contact_form_7"][i] + 
-              "</span> <span class=\"dashicons dashicons-arrow-right-alt\"></span><select name=\"gf_mapped_fields["+data["fields_contact_form_7"][i]+"]\"><option value=\"\"></option>" + select + "</select></p>";          
+    var fields = data["fields_" + integrationType];
+    for (i = 0; i < fields.length; i++) {
+      html += "<p class=\"rd-fields-mapping\"><span class=\"rd-fields-mapping-label\">" + fields[i]["label"] + 
+              "</span> <span class=\"dashicons dashicons-arrow-right-alt\"></span><select name=\""+initials+"_mapped_fields["+fields[i]["id"]+"]\"><option value=\"\"></option>" + select + "</select></p>";
     }
     return html;
   }
 
-  function getGravityFormHTML(data, select) {
-    var html = "";
-    for (i = 0; i < data["fields_gravity_forms"].length; i++) {
-      html += "<p class=\"rd-fields-mapping\"><span class=\"rd-fields-mapping-label\">" + data["fields_gravity_forms"][i]["label"] + 
-              "</span> <span class=\"dashicons dashicons-arrow-right-alt\"></span><select name=\"gf_mapped_fields["+data["fields_gravity_forms"][i]["id"]+"]\"><option value=\"\"></option>" + select + "</select></p>";
-    }
-    return html;
-  }
-
-  function setSelectedItems(data){
-    for (i = 0; i < data["fields_gf"].length; i++) {
-      select = document.getElementsByName("gf_mapped_fields["+data["fields_gf"][i]["id"]+"]")[0];
-      select.value = data["fields_gf"][i]["value"];
+  function setSelectedItems(data, integrationType, initials, form_id){
+    var fields = data["fields_" + integrationType];
+    for (i = 0; i < fields.length; i++) {
+      select = document.getElementsByName(initials + "_mapped_fields["+fields[i]["id"]+"]")[0];
+      select.value = fields[i]["value"];
     }
   }  
 }

--- a/integracao-rd-station/assets/js/woocommerce_fields.js
+++ b/integracao-rd-station/assets/js/woocommerce_fields.js
@@ -15,19 +15,45 @@ function RDSMWooCommerceFields() {
     var select = "";
 
     for (i = 0; i < fieldMapping["select_items"].length; i++) {
-      select += "<option value=" + fieldMapping["select_items"][i]["value"] + ">" + fieldMapping["select_items"][i]["value"] + "</option>";
+      select += "<option value=" + fieldMapping["select_items"][i]["api_identifier"] + ">" + fieldMapping["select_items"][i]["value"] + "</option>";
     }
 
-    document.getElementById("rdsm_fields").innerHTML = getWooCommerceHTML(fieldMapping, select);
+    var rdsmFields = document.getElementById("rdsm_fields");
+    rdsmFields.innerHTML = getWooCommerceHTML(fieldMapping, select);    
+
+    var fieldsMappingSelected = {
+      "billing_first_name": rdsmFields.dataset.billing_first_name,
+      "billing_last_name": rdsmFields.dataset.billing_last_name,
+      "billing_email": rdsmFields.dataset.billing_email,
+      "billing_phone": rdsmFields.dataset.billing_phone,
+      "billing_company": rdsmFields.dataset.billing_company,
+      "billing_country": rdsmFields.dataset.billing_country,
+      "billing_address_1": rdsmFields.dataset.billing_address_1,
+      "billing_address_2": rdsmFields.dataset.billing_address_2,
+      "billing_city": rdsmFields.dataset.billing_city,
+      "billing_state": rdsmFields.dataset.billing_state,
+      "billing_postcode": rdsmFields.dataset.billing_postcode
+    };
+
+    setSelectedItems(fieldMapping, fieldsMappingSelected);
   }
 
   function getWooCommerceHTML(data, select) {
     var html = "";
-    for (i = 0; i < data["fields_woocommerce"].length; i++) {
-      html += "<p class=\"rd-fields-mapping\"><span class=\"rd-fields-mapping-label\" style=\"float: left; width: 200px; color: #4f6d83; font-weight: bold; margin-top: 4px;\">" + data["fields_woocommerce"][i] + 
-              "</span> <span class=\"dashicons dashicons-arrow-right-alt\" style=\"line-height: unset; margin-right: 15px;\"></span><select name=\"gf_mapped_fields["+data["fields_woocommerce"][i]+"]\"><option value=\"\"></option>" + select + "</select></p>";          
+    var fields = data["fields_woocommerce"];
+    for (i = 0; i < fields.length; i++) {
+      html += "<p class=\"rd-fields-mapping\"><span class=\"rd-fields-mapping-label\" style=\"float: left; width: 200px; color: #4f6d83; font-weight: bold; margin-top: 4px;\">" + fields[i] +
+              "</span> <span class=\"dashicons dashicons-arrow-right-alt\" style=\"line-height: unset; margin-right: 15px;\"></span><select name=\"rdsm_woocommerce_settings[field_mapping]["+fields[i]+"]\"><option value=\"\"></option>" + select + "</select></p>";
     }
     return html;
+  }
+
+  function setSelectedItems(fieldMapping, fieldsMappingSelected){
+    var fields = fieldMapping["fields_woocommerce"];
+    for (i = 0; i < fields.length; i++) {
+      select = document.getElementsByName("rdsm_woocommerce_settings[field_mapping]["+fields[i]+"]")[0];
+      select.value = fieldsMappingSelected[fields[i]];
+    }
   }  
 }
 

--- a/integracao-rd-station/includes/client/rdsm_fields_api.php
+++ b/integracao-rd-station/includes/client/rdsm_fields_api.php
@@ -15,7 +15,7 @@ class RDSMFieldsAPI {
   }
 
   public function contacts_fields() {
-    $response = $this->api_client->get(CONTACTS_FIELDS);
+    $response = $this->api_client->get(CONTACTS_FIELDS);    
     return $response;
   }
 }

--- a/integracao-rd-station/includes/events/rdsm_integration_form_changed.php
+++ b/integracao-rd-station/includes/events/rdsm_integration_form_changed.php
@@ -12,55 +12,66 @@ class RDSMIntegrationFormChanged implements RDSMEventsInterface {
 
   public function get_custom_fields() {
     $form_id = $_POST['form_id'];
-    $type = $_POST['type'];
-    $post_id = $_POST['post_id'];
-    $json_result = array();
-    $fields = array();
+    $integrationType = $_POST['type'];
     $select_items = array();
-
-    $access_token = get_option('rdsm_access_token');    
-    $refresh_token = get_option('rdsm_refresh_token');
-    $user_credentials = new RDSMUserCredentials($access_token, $refresh_token);
-    $api_instance = new RDSMFieldsAPI($user_credentials);
-    $contacts_fields = json_decode($api_instance->contacts_fields()["body"], true);
+    $contacts_fields = $this->rdstation_fields();
 
     if (!empty($form_id)) {
       foreach ($contacts_fields["fields"] as $contact_field) {
         array_push($select_items, array("id" => $contact_field["uuid"], "value" => $contact_field["name"]["default"]));
       }
+      $json_result = array( 'select_items' => $select_items );
 
-      if ($type == "wpcf7") {
-        $contact_form = WPCF7_ContactForm::get_instance( $form_id );
-        $form_fields = $contact_form->scan_form_tags();
-
-        foreach ($form_fields as $field) {          
-          if ($field['type'] != "submit") {          
-            array_push($fields, $field['name']);
-          }
-        }
-        $json_result = array( 'select_items' => $select_items, 'fields_cf7' => $fields );
-      }elseif ($type == "wpgf") {
-        $gf_forms = GFAPI::get_forms();
-        $form_map = get_post_meta($post_id, 'gf_mapped_fields', true);
-        
-        foreach ($gf_forms as $form) {
-          if ($form['id'] == $form_id) {
-            foreach ($form['fields'] as $field) {
-              if(!empty($form_map[$field['id']])){
-                $value = $form_map[$field['id']];
-              }
-              else {
-                $value = '';
-              }
-              array_push($fields, array("label" => $field['label'], "id" => $field['id'], "value" => $value));
-            }
-          }
-        }
-        $json_result = array( 'select_items' => $select_items, 'fields_gf' => $fields );
+      if ($integrationType == "contact_form_7") {
+        $json_result = array( 'select_items' => $select_items, 'fields_contact_form_7' => $this->contact_form7_fields($form_id));
+      } elseif ($integrationType == "gravity_forms") {
+        $json_result = array( 'select_items' => $select_items, 'fields_gravity_forms' => $this->gravity_forms_fields($form_id));
       }
     }
 
     wp_send_json($json_result);
+  }
+
+  public function contact_form7_fields($form_id) {
+    $contact_form = WPCF7_ContactForm::get_instance( $form_id );
+    $form_fields = $contact_form->scan_form_tags();
+    $fields = array();
+
+    foreach ($form_fields as $field) {          
+      if ($field['type'] != "submit") {          
+        array_push($fields, $field['name']);
+      }
+    }
+    return $fields;
+  }
+
+  public function gravity_forms_fields($form_id) {
+    $gf_forms = GFAPI::get_forms();
+    $post_id = $_POST['post_id'];
+    $form_map = get_post_meta($post_id, 'gf_mapped_fields', true);
+    $fields = array();
+    
+    foreach ($gf_forms as $form) {
+      if ($form['id'] == $form_id) {
+        foreach ($form['fields'] as $field) {
+          if(!empty($form_map[$field['id']])){
+            $value = $form_map[$field['id']];
+          }else {
+            $value = '';
+          }
+          array_push($fields, array("label" => $field['label'], "id" => $field['id'], "value" => $value));
+        }
+      }
+    }
+    return $fields;
+  }
+
+  public function rdstation_fields() {
+    $access_token = get_option('rdsm_access_token');    
+    $refresh_token = get_option('rdsm_refresh_token');
+    $user_credentials = new RDSMUserCredentials($access_token, $refresh_token);
+    $api_instance = new RDSMFieldsAPI($user_credentials);
+    return json_decode($api_instance->contacts_fields()["body"], true);
   }
 }
 

--- a/integracao-rd-station/includes/events/rdsm_integration_form_woocommerce.php
+++ b/integracao-rd-station/includes/events/rdsm_integration_form_woocommerce.php
@@ -13,16 +13,18 @@ class RDSMIntegrationFormWooCommerce implements RDSMEventsInterface {
   public function get_fields() {   
     $select_items = array();
     $contacts_fields = $this->rdstation_fields();
+    $fields = $contacts_fields["fields"];
+    array_multisort(array_column($fields, 'name'), SORT_ASC, $fields);
     
-    foreach ($contacts_fields["fields"] as $contact_field) {
-      array_push($select_items, array("id" => $contact_field["uuid"], "value" => $contact_field["name"]["default"]));
+    foreach ($fields as $contact_field) {
+      array_push($select_items, array("api_identifier" => $contact_field["api_identifier"], "value" => $contact_field["name"]["default"]));
     }
 
     wp_send_json(array( 'select_items' => $select_items, 'fields_woocommerce' => $this->contact_woocommerce_fields()));
   }
 
   public function contact_woocommerce_fields() {
-    $fields = array(
+    $form_fields = array(
       'billing_first_name',
       'billing_last_name',
       'billing_email',
@@ -35,7 +37,8 @@ class RDSMIntegrationFormWooCommerce implements RDSMEventsInterface {
       'billing_state',
       'billing_postcode'
     );
-    return $fields;
+    
+    return $form_fields;
   }
 
   public function rdstation_fields() {

--- a/integracao-rd-station/metaboxes/RD_Metabox.php
+++ b/integracao-rd-station/metaboxes/RD_Metabox.php
@@ -39,7 +39,8 @@ class RD_Metabox {
 		if ( isset( $_POST['form_identifier'] ) ) update_post_meta( $post_id, 'form_identifier', $_POST['form_identifier'] );
 		if ( isset( $_POST['use_post_title'] ) )  update_post_meta( $post_id, 'use_post_title', $_POST['use_post_title'] );
 		if ( isset( $_POST['form_id'] ) ) update_post_meta( $post_id, 'form_id', $_POST['form_id'] );
-		if ( isset( $_POST['gf_mapped_fields'] ) ) update_post_meta( $post_id, 'gf_mapped_fields', $_POST['gf_mapped_fields'] );
+		if ( isset( $_POST['gf_mapped_fields'] ) ) update_post_meta( $post_id, 'gf_mapped_fields_'.$_POST['form_id'], $_POST['gf_mapped_fields'] );
+		if ( isset( $_POST['cf7_mapped_fields'] ) ) update_post_meta( $post_id, 'cf7_mapped_fields_'.$_POST['form_id'], $_POST['cf7_mapped_fields'] );
 	}
 }
 

--- a/integracao-rd-station/metaboxes/rdcf7.php
+++ b/integracao-rd-station/metaboxes/rdcf7.php
@@ -12,7 +12,7 @@
 		    if ( !$cf7Forms ) : ?>
 		    <p><?php _e("No forms have been found. <a href='admin.php?page=wpcf7-new'>Click here to create a new one.</a>", 'integracao-rd-station')?></p>
 		    <?php else : ?>
-		        <select id="forms_select" name="form_id" class="wpcf7">
+		        <select id="forms_select" name="form_id" data-integration-type="contact_form_7" data-post-id="">
 		            <option value=""></option>
 		                <?php
 		                foreach($cf7Forms as $cf7Form) {
@@ -24,7 +24,6 @@
 		        	<h4><?php _e('Map the fields below according to their names in RD Station.', 'integracao-rd-station') ?></h4>
 		        <?php } ?>
 		        <div id="custom_fields"></div>
-		        <span id="post_id" class="hidden"></span>
 		    <?php		    
 		    endif;
 		}

--- a/integracao-rd-station/metaboxes/rdcf7.php
+++ b/integracao-rd-station/metaboxes/rdcf7.php
@@ -12,7 +12,7 @@
 		    if ( !$cf7Forms ) : ?>
 		    <p><?php _e("No forms have been found. <a href='admin.php?page=wpcf7-new'>Click here to create a new one.</a>", 'integracao-rd-station')?></p>
 		    <?php else : ?>
-		        <select id="forms_select" name="form_id" data-integration-type="contact_form_7" data-post-id="">
+		        <?php echo "<select id=\"forms_select\" name=\"form_id\" data-integration-type=\"contact_form_7\" data-post-id=\"" . get_the_ID() . "\">" ?>
 		            <option value=""></option>
 		                <?php
 		                foreach($cf7Forms as $cf7Form) {

--- a/integracao-rd-station/metaboxes/rdgf.php
+++ b/integracao-rd-station/metaboxes/rdgf.php
@@ -10,9 +10,9 @@
 
 			if( !$gForms ) : ?>
 				<p><?php _e("No forms have been found. <a href='admin.php?page=gf_new_form'>Click here to create a new one.</a>", 'integracao-rd-station')?></p>
-		  <?php else : ?>				
-					<select id="forms_select" name="form_id" class="wpgf">
-						<option value=""> </option>
+		  <?php else : ?>
+				<?php echo "<select id=\"forms_select\" name=\"form_id\" data-integration-type=\"gravity_forms\" data-post-id=\"" . get_the_ID() . "\">" ?>
+					<option value=""> </option>
 	            <?php
                 foreach($gForms as $gForm){
                   echo "<option value=".$gForm->id.selected( $form_id, $gForm->id, false) .">".$gForm->title."</option>";
@@ -23,7 +23,6 @@
 	        	<h4><?php _e('Map the fields below according to their names in RD Station.', 'integracao-rd-station') ?></h4>
 	        <?php } ?>
 	        <div id="custom_fields"></div>
-	        <?php echo "<span id=\"post_id\" class=\"hidden\">" . get_the_ID() . "</span>" ?>
 		    <?php
 			endif;
 		}

--- a/integracao-rd-station/settings/fields_mapping.php
+++ b/integracao-rd-station/settings/fields_mapping.php
@@ -1,2 +1,0 @@
-<h4><?php _e('Map the fields below according to their names in RD Station.', 'integracao-rd-station') ?></h4>
-<div id="rdsm_fields"></div>

--- a/integracao-rd-station/settings/settings_fields.php
+++ b/integracao-rd-station/settings/settings_fields.php
@@ -24,5 +24,13 @@ class RDSettingsFields {
       'rdsm_woocommerce_settings',
       'rdsm_woocommerce_settings_section'
     );
+
+    add_settings_field(
+      'rdsm_woocommerce_field_mapping',
+      __('Field Mapping', 'integracao-rd-station'),
+      'rdsm_woocommerce_field_mapping_html',
+      'rdsm_woocommerce_settings',
+      'rdsm_woocommerce_settings_section'
+    );
   }
 }

--- a/integracao-rd-station/settings/settings_page.php
+++ b/integracao-rd-station/settings/settings_page.php
@@ -69,7 +69,6 @@ function rdstation_settings_page_callback() {
         case 'woocommerce':
           settings_fields('rdsm_woocommerce_settings');
           do_settings_sections('rdsm_woocommerce_settings');
-          include 'fields_mapping.php';
           break;
       }
 
@@ -82,6 +81,27 @@ function rdstation_settings_page_callback() {
 function rdsm_woocommerce_conversion_identifier_html() {
   $options = get_option( 'rdsm_woocommerce_settings' ); ?>
   <input type='text' name='rdsm_woocommerce_settings[conversion_identifier]' size="32" value='<?php echo $options['conversion_identifier']; ?>'>
+  <?php
+}
+
+function rdsm_woocommerce_field_mapping_html() {
+  $options = get_option( 'rdsm_woocommerce_settings' );
+  $field_mapping = $options['field_mapping'];
+  ?>
+  <h4><?php _e('Map the fields below according to their names in RD Station.', 'integracao-rd-station') ?></h4>
+  <?php echo "<div id=\"rdsm_fields\" 
+                data-billing_first_name=\"" .$field_mapping["billing_first_name"]."\"
+                data-billing_last_name=\""  .$field_mapping["billing_last_name"]."\"
+                data-billing_email=\""      .$field_mapping["billing_email"]."\"
+                data-billing_phone=\""      .$field_mapping["billing_phone"]."\"
+                data-billing_company=\""    .$field_mapping["billing_company"]."\"
+                data-billing_country=\""    .$field_mapping["billing_country"]."\"
+                data-billing_address_1=\""  .$field_mapping["billing_address_1"]."\"
+                data-billing_address_2=\""  .$field_mapping["billing_address_2"]."\"
+                data-billing_city=\""       .$field_mapping["billing_city"]."\"
+                data-billing_state=\""      .$field_mapping["billing_state"]."\"
+                data-billing_postcode=\""   .$field_mapping["billing_postcode"]."\"
+              ></div>" ?>
   <?php
 }
 


### PR DESCRIPTION
Criar camada para persistir os mapeamentos no banco de dados

 - Persistindo no WordPress os dados selecionados pelo cliente na tela de mapeamento de campos
 - Funcionando para Contact Form 7, Gravity Forms e Woo Commerce