### PR TITLE
Enviando menu suspenso como string quando permitir multipla seleção n…

### DIFF
--- a/integracao-rd-station/includes/client/rdsm_api.php
+++ b/integracao-rd-station/includes/client/rdsm_api.php
@@ -55,7 +55,7 @@ class RDSMAPI {
       return false;
     }
 
-    $response = wp_remote_get(sprintf("%s/%s%s", REFRESH_TOKEN_URL, "refresh_token=", $refresh_token));
+    $response = wp_remote_get(sprintf("%s/%s%s", REFRESH_TOKEN_URL, "?refresh_token=", $refresh_token));
 
     if (wp_remote_retrieve_response_code($response) == 200) {
       $parsed_credentials = json_decode(wp_remote_retrieve_body($response));

--- a/integracao-rd-station/includes/resources/rdsm_event.php
+++ b/integracao-rd-station/includes/resources/rdsm_event.php
@@ -148,6 +148,9 @@ class RDSMEvent {
       }else {
         if ($parse_to_string) {
           $value = $value[0];
+          if (empty($value)) {
+            return $response;
+          }
         }
         $response += array($name => $value);
       }

--- a/integracao-rd-station/includes/resources/rdsm_event.php
+++ b/integracao-rd-station/includes/resources/rdsm_event.php
@@ -96,7 +96,11 @@ class RDSMEvent {
     }else {
       foreach ($form_fields as $field) {
         if ($field['type'] != "submit") {
-          $response = $this->get_value($response, $form_map, $form_data, $field, $identifier, true);
+          if (($field['type'] == "select") && (!in_array("multiple", $field['options']))) {
+            $response = $this->get_value($response, $form_map, $form_data, $field, $identifier, true, true);
+          }else {
+            $response = $this->get_value($response, $form_map, $form_data, $field, $identifier, true, false);
+          }
         }
       }
     }
@@ -121,10 +125,10 @@ class RDSMEvent {
         foreach ($form['fields'] as $field) {
           if ($field['type'] == "checkbox") {            
             foreach ($field['inputs'] as $input) {
-              $response = $this->get_value($response, $form_map, $form_data, $input, 'id', true);
+              $response = $this->get_value($response, $form_map, $form_data, $input, 'id', true, false);
             }
           }else {
-            $response = $this->get_value($response, $form_map, $form_data, $field, 'id', false);
+            $response = $this->get_value($response, $form_map, $form_data, $field, 'id', false, false);
           }
         }
       }
@@ -132,7 +136,7 @@ class RDSMEvent {
     return $response;
   }
 
-  private function get_value($response, $form_map, $form_data, $field, $identifier, $is_checkbox) {
+  private function get_value($response, $form_map, $form_data, $field, $identifier, $is_checkbox, $parse_to_string) {
     $name = $form_map[$field[$identifier]];    
     if(!empty($name)){          
       $value = $form_data[$field[$identifier]];
@@ -142,6 +146,9 @@ class RDSMEvent {
           $response += array('legal_bases' => array(array('category' => 'communications', 'type' => 'consent', 'status' => 'granted')));
         }
       }else {
+        if ($parse_to_string) {
+          $value = $value[0];
+        }
         $response += array($name => $value);
       }
     }

--- a/integracao-rd-station/integracao-rd-station.php
+++ b/integracao-rd-station/integracao-rd-station.php
@@ -4,7 +4,7 @@
 Plugin Name: 	RD Station
 Plugin URI: 	https://wordpress.org/plugins/integracao-rdstation
 Description:  Integre seus formulários de contato do WordPress com o RD Station
-Version:      5.0.2
+Version:      5.0.3
 Author:       RD Station
 Author URI:   https://www.rdstation.com/
 License:      GPL2

--- a/integracao-rd-station/readme.txt
+++ b/integracao-rd-station/readme.txt
@@ -4,7 +4,7 @@ Donate link: -
 Tags: integrations, forms, contact form, rd station, resultados digitais
 Requires at least: 4.7
 Tested up to: 5.5.3
-Stable tag: 5.0.2
+Stable tag: 5.0.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,10 +40,19 @@ More info about the version 5.0.0: [https://ajuda.rdstation.com.br/hc/pt-br/arti
 
 == Changelog ==
 
-= 5.0 =
-* Mapping fields RD Station
-* API v2 RD Station
-* More info about the version 5.0.0: [https://ajuda.rdstation.com.br/hc/pt-br/articles/360054981272](https://ajuda.rdstation.com.br/hc/pt-br/articles/360054981272)
+5.0.3
+Sending drop-down menu from Contact Forms 7 as single text when Allow multiple selections aren't checked
+More info about the version 5.0.2: https://ajuda.rdstation.com.br/hc/pt-br/articles/360054981272
+
+5.0.2
+Adding company fields to the field mapping list
+
+5.0.1
+Fixing problem with corrupted files in version 5.0.0
+
+5.0
+Mapping fields RD Station
+API v2 RD Station
 
 = 4.0 =
 * One-click RD Station integration


### PR DESCRIPTION
Enviando menu suspenso como string quando permitir múltipla seleção não estiver marcado
 - No Contact Form 7 é possível criar uma campo de seleção suspensa que pode enviar múltiplas escolhas ou um valor simples, isso é selecionado quando o elemento é adicionado
 - No RDSM também temos esse comportamento para os custom fields mas em elementos separados
 - O CF7 sempre envia esse campo como um array mas o RDSM caso esteja selecionado o campo de select simples recebe uma string e não um array, por isso agora quando o campo do CF7 está marcado como simples eu envio uma string e quando está marcado como múltipla escolha eu envio o array
<img width="642" alt="Screen Shot 2021-02-03 at 08 12 43" src="https://user-images.githubusercontent.com/75985246/106752324-12bc4800-6609-11eb-9700-818f37734d45.png">
