### PR TITLE
Fix bugs data format

### DIFF
--- a/integracao-rd-station/includes/events/rdsm_integration_form_changed.php
+++ b/integracao-rd-station/includes/events/rdsm_integration_form_changed.php
@@ -61,18 +61,12 @@ class RDSMIntegrationFormChanged implements RDSMEventsInterface {
 
     foreach ($gf_forms as $form) {
       if ($form['id'] == $form_id) {
-        foreach ($form['fields'] as $field) {
-          if ($field['type'] == "checkbox") {
-            foreach ($field['inputs'] as $input) {
-              $fields = $this->get_value($form_map, $fields, $input, 'id', 'label');
-            }
-          }else {
-            $fields = $this->get_value($form_map, $fields, $field, 'id', 'label');
-          }          
+        foreach ($form['fields'] as $field) {          
+          $fields = $this->get_value($form_map, $fields, $field, 'id', 'label');
         }
       }
     }
-    return $fields;
+    return $fields;    
   }
 
   public function get_value($form_map, $fields, $field, $identifier, $label) {

--- a/integracao-rd-station/integracao-rd-station.php
+++ b/integracao-rd-station/integracao-rd-station.php
@@ -4,7 +4,7 @@
 Plugin Name: 	RD Station
 Plugin URI: 	https://wordpress.org/plugins/integracao-rdstation
 Description:  Integre seus formulários de contato do WordPress com o RD Station
-Version:      5.0.3
+Version:      5.0.4
 Author:       RD Station
 Author URI:   https://www.rdstation.com/
 License:      GPL2

--- a/integracao-rd-station/readme.txt
+++ b/integracao-rd-station/readme.txt
@@ -4,7 +4,7 @@ Donate link: -
 Tags: integrations, forms, contact form, rd station, resultados digitais
 Requires at least: 4.7
 Tested up to: 5.5.3
-Stable tag: 5.0.3
+Stable tag: 5.0.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,19 +40,24 @@ More info about the version 5.0.0: [https://ajuda.rdstation.com.br/hc/pt-br/arti
 
 == Changelog ==
 
-5.0.3
-Sending drop-down menu from Contact Forms 7 as single text when Allow multiple selections aren't checked
-More info about the version 5.0.2: https://ajuda.rdstation.com.br/hc/pt-br/articles/360054981272
+= 5.0.4 =
+* Sending drop-down menu from Contact Forms 7 as single text when Allow multiple selections aren't checked
+* Fixing invalid data type errors
+* More info about the version 5.0.4: [https://ajuda.rdstation.com.br/hc/pt-br/articles/360054981272](https://ajuda.rdstation.com.br/hc/pt-br/articles/360054981272)
 
-5.0.2
-Adding company fields to the field mapping list
+= 5.0.3 =
+* Sending drop-down menu from Contact Forms 7 as single text when Allow multiple selections aren't checked
+* Fixing refresh token error
 
-5.0.1
-Fixing problem with corrupted files in version 5.0.0
+= 5.0.2 =
+* Adding company fields to the field mapping list
 
-5.0
-Mapping fields RD Station
-API v2 RD Station
+= 5.0.1 =
+* Fixing problem with corrupted files in version 5.0.0
+
+= 5.0 =
+* Mapping fields RD Station
+* API v2 RD Station
 
 = 4.0 =
 * One-click RD Station integration


### PR DESCRIPTION
Analisando e corrigindo problemas com formato de dados no plugin WP
 - Corrigindo erro no select CF7 quando está selecionado como required, a validação anterior checava se o type era "select" mas quando o requerid é selecionado muda para "select*"
 - Corrigindo erro na formatação do campo multi-selecao do GF, antes estava trazendo o array dentro de uma string ""["1", "2"]"" desta forma
 - Mudando comportamento dos checkboxs do GF, antes cada opção do checkbox podia ser mapeada individualmente, agora o grupo do checkbox é mapeado e as opções são enviadas de acordo com as que foram selecionadas. Isso mudou a lógica do lgpd, o cliente agora precisar criar um grupo de checkboxs com somente uma opção, porque ele só vai conseguir mapear o grupo inteiro como consentimento de comunicão