### PR TITLE
add produtos to mapped woocommerce fields

### DIFF
--- a/integracao-rd-station/assets/js/woocommerce_fields.js
+++ b/integracao-rd-station/assets/js/woocommerce_fields.js
@@ -32,7 +32,8 @@ function RDSMWooCommerceFields() {
       "endereço2":    rdsmFields.dataset.endereço2,
       "cidade":       rdsmFields.dataset.cidade,
       "estado":       rdsmFields.dataset.estado,
-      "cep":          rdsmFields.dataset.cep
+      "cep":          rdsmFields.dataset.cep,
+      "produtos":     rdsmFields.dataset.produtos
     };
 
     setSelectedItems(fieldMapping, fieldsMappingSelected);

--- a/integracao-rd-station/includes/events/rdsm_integration_form_woocommerce.php
+++ b/integracao-rd-station/includes/events/rdsm_integration_form_woocommerce.php
@@ -35,9 +35,10 @@ class RDSMIntegrationFormWooCommerce implements RDSMEventsInterface {
       'endereço2',
       'cidade',
       'estado',
-      'cep'
+      'cep',
+      'produtos'
     );
-    
+
     return $form_fields;
   }
 

--- a/integracao-rd-station/includes/resources/rdsm_event.php
+++ b/integracao-rd-station/includes/resources/rdsm_event.php
@@ -213,7 +213,8 @@ class RDSMEvent {
       $field_mapping['endereço2']   => $form_data['endereço2'],
       $field_mapping['cidade']      => $form_data['cidade'],
       $field_mapping['estado']      => $form_data['estado'],
-      $field_mapping['cep']         => $form_data['cep'] 
+      $field_mapping['cep']         => $form_data['cep'],
+      $field_mapping['produtos']    => $form_data['produtos']
     );
 
     return $response;

--- a/integracao-rd-station/integracao-rd-station.php
+++ b/integracao-rd-station/integracao-rd-station.php
@@ -4,7 +4,7 @@
 Plugin Name: 	RD Station
 Plugin URI: 	https://wordpress.org/plugins/integracao-rdstation
 Description:  Integre seus formulários de contato do WordPress com o RD Station
-Version:      5.0.4
+Version:      5.0.5
 Author:       RD Station
 Author URI:   https://www.rdstation.com/
 License:      GPL2

--- a/integracao-rd-station/readme.txt
+++ b/integracao-rd-station/readme.txt
@@ -4,7 +4,7 @@ Donate link: -
 Tags: integrations, forms, contact form, rd station, resultados digitais
 Requires at least: 4.7
 Tested up to: 5.5.3
-Stable tag: 5.0.4
+Stable tag: 5.0.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,10 +40,13 @@ More info about the version 5.0.0: [https://ajuda.rdstation.com.br/hc/pt-br/arti
 
 == Changelog ==
 
+= 5.0.5 =
+* Adding products to WooCommerce mapping fields list
+* More info about the version 5.0.5: [https://ajuda.rdstation.com.br/hc/pt-br/articles/360054981272](https://ajuda.rdstation.com.br/hc/pt-br/articles/360054981272)
+
 = 5.0.4 =
 * Sending drop-down menu from Contact Forms 7 as single text when Allow multiple selections aren't checked
 * Fixing invalid data type errors
-* More info about the version 5.0.4: [https://ajuda.rdstation.com.br/hc/pt-br/articles/360054981272](https://ajuda.rdstation.com.br/hc/pt-br/articles/360054981272)
 
 = 5.0.3 =
 * Sending drop-down menu from Contact Forms 7 as single text when Allow multiple selections aren't checked

--- a/integracao-rd-station/settings/settings_page.php
+++ b/integracao-rd-station/settings/settings_page.php
@@ -120,6 +120,7 @@ function rdsm_woocommerce_field_mapping_html() {
                   data-cidade=\""     .$field_mapping["cidade"]."\"
                   data-estado=\""     .$field_mapping["estado"]."\"
                   data-cep=\""        .$field_mapping["cep"]."\"
+                  data-produtos=\""   .$field_mapping["produtos"]."\"
                 ></div>" 
     ?>    
   </div>


### PR DESCRIPTION
Permitindo envio de produtos pelo  WooCommerce no plugin WP
 - Enviando o array de produtos que o woocomerce retorna
 - Usuário precisa cadastrar um campo múltipla escolha no RDSM e fazer o mapeamento de produtos para este campo
 - O campo produtos agora aparece na tela de integração do WooCommerce para ser mapeado
 - Os itens do campo no RDSM precisam ser exatamente iguais aos itens que estão sendo enviados(case sensitive)