### PR TITLE
create log file and insert response events API body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 /wp-content/languages/*
 /wp-content/uploads/*
+/integracao-rd-station/log.txt

--- a/integracao-rd-station/config.php
+++ b/integracao-rd-station/config.php
@@ -2,6 +2,7 @@
 
 define('RDSM_ASSETS_URL', plugin_dir_url(__FILE__) . '/assets');
 define('RDSM_SRC_DIR', dirname(__FILE__) . '/includes');
+define('RDSM_LOG_FILE_PATH', plugin_dir_path( __FILE__ ) . '/log.txt');
 
 // URIs
 define('LEGACY_API_URL', 'https://app.rdstation.com.br/api/1.3');

--- a/integracao-rd-station/includes/client/rdsm_api.php
+++ b/integracao-rd-station/includes/client/rdsm_api.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once(RDSM_SRC_DIR . '/helpers/rdsm_log_file_helper.php');
+
 class RDSMAPI {
   private $api_url;
   private $user_credentials;
@@ -15,7 +17,8 @@ class RDSMAPI {
     }
 
     $response = wp_remote_get(sprintf("%s%s", $this->api_url, $resource), $args);
-    
+    RDSMLogFileHelper::write_to_log_file($response['body']);
+
     if ($this->handle_expired_token($response)) {
       return $this->get($resource, $args);
     }
@@ -29,7 +32,8 @@ class RDSMAPI {
     }
 
     $response = wp_remote_post(sprintf("%s%s", $this->api_url, $resource), $args);
-    
+    RDSMLogFileHelper::write_to_log_file($response['body']);
+
     if ($this->handle_expired_token($response)) {
       return $this->post($resource, $args);
     }
@@ -56,6 +60,7 @@ class RDSMAPI {
     }
 
     $response = wp_remote_get(sprintf("%s/%s%s", REFRESH_TOKEN_URL, "?refresh_token=", $refresh_token));
+    RDSMLogFileHelper::write_to_log_file($response['body']);
 
     if (wp_remote_retrieve_response_code($response) == 200) {
       $parsed_credentials = json_decode(wp_remote_retrieve_body($response));

--- a/integracao-rd-station/includes/client/rdsm_events_api.php
+++ b/integracao-rd-station/includes/client/rdsm_events_api.php
@@ -1,7 +1,6 @@
 <?php
 
 require_once('rdsm_api.php');
-require_once(RDSM_SRC_DIR . '/helpers/rdsm_log_file_helper.php');
 
 class RDSMEventsAPI {
   private $api_client;
@@ -25,7 +24,6 @@ class RDSMEventsAPI {
     $args = array_merge($this->default_request_args, $body);
     
     $response = $this->api_client->post(EVENTS, $args);
-    RDSMLogFileHelper::write_to_log_file($response['body']);
 
     if (is_wp_error($response)) {
       unset($event->payload);      

--- a/integracao-rd-station/includes/client/rdsm_events_api.php
+++ b/integracao-rd-station/includes/client/rdsm_events_api.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once('rdsm_api.php');
+require_once(RDSM_SRC_DIR . '/helpers/rdsm_log_file_helper.php');
 
 class RDSMEventsAPI {
   private $api_client;
@@ -24,9 +25,10 @@ class RDSMEventsAPI {
     $args = array_merge($this->default_request_args, $body);
     
     $response = $this->api_client->post(EVENTS, $args);
+    RDSMLogFileHelper::write_to_log_file($response['body']);
 
     if (is_wp_error($response)) {
-      unset($event->payload);
+      unset($event->payload);      
     }
     return $response;
   }

--- a/integracao-rd-station/includes/helpers/rdsm_log_file_helper.php
+++ b/integracao-rd-station/includes/helpers/rdsm_log_file_helper.php
@@ -1,0 +1,13 @@
+<?php
+
+class RDSMLogFileHelper {
+
+  public static function write_to_log_file($value) {
+    $time = date( "F jS Y, H:i", time()-10800 );
+    $log = "#$time\r\n$value\r\n";
+    $file = RDSM_LOG_FILE_PATH;
+    $open = fopen( $file, "a" );
+    $write = fputs( $open, $log );
+    fclose( $open );
+  }
+}

--- a/integracao-rd-station/includes/helpers/rdsm_log_file_helper.php
+++ b/integracao-rd-station/includes/helpers/rdsm_log_file_helper.php
@@ -3,7 +3,7 @@
 class RDSMLogFileHelper {
 
   public static function write_to_log_file($value) {
-    $time = date( "F jS Y, H:i", time()-10800 );
+    $time = date( "F jS Y, H:i P", time() );
     $log = "#$time\r\n$value\r\n";
     $file = RDSM_LOG_FILE_PATH;
     $open = fopen( $file, "a" );


### PR DESCRIPTION
Criar arquivo de log
 - Criar arquivo log.txt na raiz do plugin
 - Quando a API de eventos for acionada o response body deve ser inserido no log.txt
 - A data e hora do evento devem ser exibidos no log.txt

Como testar:
 - Ir em páginas e criar um formulário do gravity forms ou do Contact Form 7 ou ir na loja do woocommerce
 - Criar uma integração para o formulário escolhido
 - Realizar uma conversão
 - O retorno deve aparecer no arquivo log.txt na raiz do plugin, com o event_uuid em caso de sucesso ou com a mensagem de erro em caso de erro