### PR TITLE
Removing log error token expired

### DIFF
--- a/integracao-rd-station/assets/js/log_file.js
+++ b/integracao-rd-station/assets/js/log_file.js
@@ -12,6 +12,18 @@ function RDSMLogFile() {
     });
   }
 
+  this.clearLogFile = function() {
+    jQuery.ajax({
+      url: ajaxurl,
+      method: 'POST',
+      data: { action: 'rdsm-clear-log-file' },
+      success: function(data) {
+        if (data == 0)
+          rdsm_log_screen.value = "";
+      }
+    });
+  }
+
   function renderLogScreen(log) {
     rdsm_log_screen.value += log;
   }
@@ -27,8 +39,13 @@ function copyLogToClipboard() {
   copyLog.value = value;
 }
 
+function clearLog() {
+  logFile = new RDSMLogFile();
+  logFile.clearLogFile();
+}
+
 function load() {
-  logFile = new RDSMLogFile();  
+  logFile = new RDSMLogFile();
   logFile.loadLogFile();
 }
 

--- a/integracao-rd-station/includes/client/rdsm_api.php
+++ b/integracao-rd-station/includes/client/rdsm_api.php
@@ -16,14 +16,14 @@ class RDSMAPI {
       $args['headers'] = $this->authorization_header($args);
     }
 
-    $response = wp_remote_get(sprintf("%s%s", $this->api_url, $resource), $args);
-
-    if ($this->is_response_error($response)) {
-      RDSMLogFileHelper::write_to_log_file($response['body']);
-    }
+    $response = wp_remote_get(sprintf("%s%s", $this->api_url, $resource), $args);    
 
     if ($this->handle_expired_token($response)) {
       return $this->get($resource, $args);
+    }
+
+    if ($this->is_response_error($response)) {
+      RDSMLogFileHelper::write_to_log_file($response['body']);
     }
 
     return $response;
@@ -35,7 +35,11 @@ class RDSMAPI {
     }
 
     $response = wp_remote_post(sprintf("%s%s", $this->api_url, $resource), $args);
-    $log = $response['body'];
+    $log = $response['body'];    
+    
+    if ($this->handle_expired_token($response)) {
+      return $this->post($resource, $args);
+    }
 
     if ($this->is_response_error($response)) {
       $payload = $args['body'];
@@ -43,10 +47,6 @@ class RDSMAPI {
     }
 
     RDSMLogFileHelper::write_to_log_file($log);
-    
-    if ($this->handle_expired_token($response)) {
-      return $this->post($resource, $args);
-    }
     
     return $response;
   }

--- a/integracao-rd-station/includes/events/rdsm_log_file.php
+++ b/integracao-rd-station/includes/events/rdsm_log_file.php
@@ -7,10 +7,15 @@ class RDSMLogFile implements RDSMEventsInterface {
 
   public function register_hooks() {
     add_action('wp_ajax_rdsm-log-file', array($this, 'load_log_file'));
+    add_action('wp_ajax_rdsm-clear-log-file', array($this, 'clear_log_file'));
   }
 
   public function load_log_file() {
     wp_send_json(RDSMLogFileHelper::get_log_file());
+  }
+
+  public function clear_log_file() {
+    wp_send_json(RDSMLogFileHelper::clear_log_file());
   }
 }
 

--- a/integracao-rd-station/includes/helpers/rdsm_log_file_helper.php
+++ b/integracao-rd-station/includes/helpers/rdsm_log_file_helper.php
@@ -9,7 +9,7 @@ class RDSMLogFileHelper {
 	    $open = fopen( $file_path, "a" );
 	    if (file_exists($file_path)) {
 		    fputs( $open, $log );
-		    RDSMLogFileHelper::clear_log_file( $file_path );
+		    RDSMLogFileHelper::limit_log_file( $file_path );
 		    fclose( $open );
 		}
   	}
@@ -22,11 +22,15 @@ class RDSMLogFileHelper {
   		return (strpos(file_get_contents(RDSM_LOG_FILE_PATH . get_option('rdsm_refresh_token')), "errors") !== false);
   	}
 
-  	private static function clear_log_file($file_path) {
+  	private static function limit_log_file($file_path) {
 		$file = file($file_path);
 		for ($i = 0;count($file) > RDSM_LOG_FILE_LIMIT;$i++) {
 		  	unset($file[$i]);
 		}
 		file_put_contents($file_path, $file);
+  	}
+
+  	public static function clear_log_file() {
+  		return file_put_contents(RDSM_LOG_FILE_PATH . get_option('rdsm_refresh_token'), "");
   	}
 }

--- a/integracao-rd-station/settings/settings_page.php
+++ b/integracao-rd-station/settings/settings_page.php
@@ -92,6 +92,7 @@ function rdsm_integrations_log_html() {
     <h3 class="alert-box"><?php _e('There are conversions that returned an error, check the log for more information', 'integracao-rd-station') ?></h3>
   <?php } ?>
   <a class="button" href="#" onclick="copyLogToClipboard()"><?php _e("Encrypt and Copy", 'integracao-rd-station')?></a>
+  <a class="button" href="#" onclick="if(confirm('After this action, the data could not be recovered. Are you sure you want to clear the log?')) clearLog();"><?php _e("Clear Log", 'integracao-rd-station')?></a>
   <textarea readonly id="rdsm_log_screen" rows="50"></textarea>
   <?php
 }


### PR DESCRIPTION
Mensagem de erro de token inválido aparece todo dia quando o token expira e está fazendo clientes abrirem tickets no suporte
 - Mensagem de token expired não é mais exibida, a mensagem de token inválido só é exibida no caso da tentativa do refresh token não funcionar
 - Um botão de clear log foi adicionado a tela de log, para o usuário ter a opção de parar de ver as mensagens de erro nas telas de integração, após ele corrigir os erros apontados no log ele pode limpar esse log

Como testar:
 - Ao entrar na tela de log do plugin a mensagem de erro token inválido com a data atual não deve ser exibida
 - Ao clicar no botão Clear Log na tela de log uma confirmação deve aparecer na tela, caso o usuário clique em OK o log deve ser deletado