### PR TITLE
concat name fields and code refactoring

### DIFF
--- a/integracao-rd-station/integracao-rd-station.php
+++ b/integracao-rd-station/integracao-rd-station.php
@@ -4,7 +4,7 @@
 Plugin Name: 	RD Station
 Plugin URI: 	https://wordpress.org/plugins/integracao-rdstation
 Description:  Integre seus formulários de contato do WordPress com o RD Station
-Version:      5.0.5
+Version:      5.1.1
 Author:       RD Station
 Author URI:   https://www.rdstation.com/
 License:      GPL2

--- a/integracao-rd-station/readme.txt
+++ b/integracao-rd-station/readme.txt
@@ -4,7 +4,7 @@ Donate link: -
 Tags: integrations, forms, contact form, rd station, resultados digitais
 Requires at least: 4.7
 Tested up to: 5.5.3
-Stable tag: 5.0.5
+Stable tag: 5.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,9 +40,16 @@ More info about the version 5.0.0: [https://ajuda.rdstation.com.br/hc/pt-br/arti
 
 == Changelog ==
 
+= 5.1.1 =
+* Removing refresh token error from Log Screen and adding clear log button
+* Fix error in the integration with advanced fields Gravity Forms
+* More info about the version 5.1.1: [https://ajuda.rdstation.com.br/hc/pt-br/articles/360054981272](https://ajuda.rdstation.com.br/hc/pt-br/articles/360054981272)
+
+= 5.1.0 =
+* Log Screen
+
 = 5.0.5 =
 * Adding products to WooCommerce mapping fields list
-* More info about the version 5.0.5: [https://ajuda.rdstation.com.br/hc/pt-br/articles/360054981272](https://ajuda.rdstation.com.br/hc/pt-br/articles/360054981272)
 
 = 5.0.4 =
 * Sending drop-down menu from Contact Forms 7 as single text when Allow multiple selections aren't checked


### PR DESCRIPTION
# Concatenar nome e sobrenome da aba de campos avançados do Gravity Forms
 - Os campos avançados do tipo 'name' do Gravity Forms agora são concatenados em uma string e enviados para o campo name do RDSM
 - Antes os campos eram enviados separadamente em um array, ocasionando erro na comunicação com a API que espera uma string para o campo name

# Como Testar
 - No menu lateral clique em Formulários, adicione um novo ou altere um existente inserindo o campo avançado Nome que se encontra na lateral direita da tela
 - Configure o campo como desejar, por padrão ele vem com nome e sobrenome mas é possível adicionar prefixo, nome do meio e sufixo
 - Crie uma página e adicione o formulário que você criou
 - Crie uma integração para o formulário que você criou, mapeie o campo de nome. Caso ele não seja mapeado com o campo Nome do RDSM lembrar de criar outro campo e mapear com o nome que é um campo obrigatório
 - Clique no link da página e preencha o formulário, é importante que também tenha o campo email, pois é um campo obrigatório
 - Na página de leads do RDSM deve aparecer um novo lead com os nomes que você preencheu no formulário